### PR TITLE
Set `word-break: initial` for max length display in `FieldText` component

### DIFF
--- a/src/components/fieldText/fieldText.module.scss
+++ b/src/components/fieldText/fieldText.module.scss
@@ -77,7 +77,10 @@
   border: 1px solid var(--rp-ui-color-field-border-3);
   border-radius: 3px;
   background-color: var(--rp-ui-color-field-bg-3);
-  transition: width 200ms, padding 200ms, border 100ms;
+  transition:
+    width 200ms,
+    padding 200ms,
+    border 100ms;
 
   &.default-width {
     width: 240px;
@@ -249,6 +252,7 @@
   margin-left: 15px;
   align-self: end;
   color: var(--rp-ui-base-e-300);
+  word-break: initial;
 }
 
 .error-text {


### PR DESCRIPTION
## Purpose

To avoid style regression of inputs within modals in service-ui repository because [styles](https://github.com/reportportal/service-ui/blob/742afe32fd001be696b77c3ced74272185ff08cc/app/src/components/main/modal/modalLayout/modalContent/modalContent.scss#L22) there