### PR TITLE
correct fieldText background, add some details for the docs control panel, group stories by categories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -52,6 +52,12 @@ const preview: Preview = {
     docs: {
       toc: true,
     },
+    options: {
+      storySort: {
+        method: 'alphabetical',
+        locales: 'en-US',
+      }
+    },
   },
 };
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -29,7 +29,10 @@ const preview: Preview = {
       toolbar: {
         title: 'Theme',
         icon: 'circlehollow',
-        items: ['light', 'dark'],
+        items: [
+          { value: 'light', icon: 'circlehollow', title: 'Light' },
+          { value: 'dark', icon: 'circle', title: 'Dark' }
+        ],
         dynamicTitle: true,
       },
     },
@@ -44,6 +47,10 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/,
       },
+      expanded: true,
+    },
+    docs: {
+      toc: true,
     },
   },
 };

--- a/src/components/bubblesLoader/bubblesLoader.stories.tsx
+++ b/src/components/bubblesLoader/bubblesLoader.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { BubblesLoader } from './bubblesLoader';
 
 const meta: Meta<typeof BubblesLoader> = {
-  title: 'Bubbles Loader',
+  title: 'Data Display/Bubbles Loader',
   component: BubblesLoader,
   parameters: {
     layout: 'centered',

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from './button';
 
 const meta: Meta<typeof Button> = {
-  title: 'Button',
+  title: 'Buttons/Button',
   component: Button,
   parameters: {
     layout: 'centered',

--- a/src/components/checkbox/checkbox.stories.tsx
+++ b/src/components/checkbox/checkbox.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Checkbox } from './checkbox';
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'Checkbox',
+  title: 'Controls/Checkbox',
   component: Checkbox,
   parameters: {
     layout: 'centered',

--- a/src/components/datePicker/datePicker.stories.tsx
+++ b/src/components/datePicker/datePicker.stories.tsx
@@ -6,7 +6,7 @@ import { DatePicker } from './datePicker';
 import { registerDatePickerLocale } from './utils';
 
 const meta: Meta<typeof DatePicker> = {
-  title: 'DatePicker',
+  title: 'Controls/DatePicker',
   component: DatePicker,
   parameters: {
     layout: 'centered',

--- a/src/components/dropdown/dropdown.stories.tsx
+++ b/src/components/dropdown/dropdown.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '@components/button';
 import './stories.scss';
 
 const meta: Meta<typeof Dropdown> = {
-  title: 'Dropdown',
+  title: 'Controls/Dropdown',
   component: Dropdown,
   parameters: {
     layout: 'centered',

--- a/src/components/fieldNumber/fieldNumber.stories.tsx
+++ b/src/components/fieldNumber/fieldNumber.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { FieldNumber } from './fieldNumber';
 
 const meta: Meta<typeof FieldNumber> = {
-  title: 'Field Number',
+  title: 'Fields/Field Number',
   component: FieldNumber,
   parameters: {
     layout: 'centered',

--- a/src/components/fieldText/constants.ts
+++ b/src/components/fieldText/constants.ts
@@ -1,0 +1,68 @@
+import type { ArgTypes } from '@storybook/react';
+
+import { InputType } from './types';
+
+export const ARG_TYPES: ArgTypes = {
+  title: {
+    control: 'text',
+    description: 'The value for the title attribute.',
+    table: { type: { summary: 'string' } },
+  },
+  value: {
+    control: 'text',
+    description: 'The value entered in the input field.',
+    table: { type: { summary: 'string' } },
+  },
+  label: {
+    control: 'text',
+    description: 'The label text associated with the input.',
+    table: { type: { summary: 'string' } },
+  },
+  error: {
+    control: 'text',
+    description: 'The error message displayed when validation fails.',
+    if: { arg: 'touched' },
+    table: { type: { summary: 'string' } },
+  },
+  placeholder: {
+    control: 'text',
+    description: 'The placeholder text displayed in the input.',
+    table: { type: { summary: 'string' } },
+  },
+  disabled: {
+    control: 'boolean',
+    description: 'Indicates whether the input is disabled.',
+    table: { type: { summary: 'boolean' } },
+  },
+  clearable: {
+    control: 'boolean',
+    description: 'Specifies whether a clear button is visible.',
+    table: { type: { summary: 'boolean' } },
+  },
+  touched: {
+    control: 'boolean',
+    description: 'Indicates whether the input has lost focus.',
+    table: { type: { summary: 'boolean' } },
+  },
+  defaultWidth: {
+    control: 'boolean',
+    description: 'Specifies if the input has a default width.',
+    table: { type: { summary: 'boolean' } },
+  },
+  isRequired: {
+    control: 'boolean',
+    description: 'Indicates whether the input is required.',
+    table: { type: { summary: 'boolean' } },
+  },
+  collapsible: {
+    control: 'boolean',
+    description: 'Specifies if the input is collapsible.',
+    table: { type: { summary: 'boolean' } },
+  },
+  loading: { control: 'boolean', table: { type: { summary: 'boolean' } } },
+  type: {
+    options: [InputType.TEXT, InputType.PASSWORD, InputType.EMAIL],
+    control: 'radio',
+    table: { type: { summary: 'string' } },
+  },
+};

--- a/src/components/fieldText/fieldText.module.scss
+++ b/src/components/fieldText/fieldText.module.scss
@@ -91,6 +91,11 @@
     border-width: 0;
     overflow: hidden;
     padding: 0;
+    background-color: transparent;
+
+    &:hover {
+      background-color: transparent;
+    }
 
     .placeholder {
       display: none;
@@ -99,7 +104,6 @@
 
   &:hover:not(.disabled) {
     border-color: var(--rp-ui-color-field-border-3-hover);
-    background-color: var(--rp-ui-color-field-bg-3-hover);
   }
 
   &:focus-within:not(.error.touched) {

--- a/src/components/fieldText/fieldText.stories.tsx
+++ b/src/components/fieldText/fieldText.stories.tsx
@@ -1,30 +1,48 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { DeleteIcon } from '@components/icons';
-import { FieldText } from './fieldText';
-import { ChangeEvent, useRef, useState } from 'react';
+import { DeleteIcon, SearchIcon } from '@components/icons';
+import { FieldText, FieldTextProps } from './fieldText';
+import { InputType } from './types';
+import { ARG_TYPES } from './constants';
+import { ChangeEvent, useEffect, useRef, useState, FC } from 'react';
 
+const FieldTextWithHooks: FC<FieldTextProps> = (args) => {
+  const [value, setValue] = useState(args.value || '');
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (args.value) {
+      setValue(args.value);
+    }
+  }, [args.value]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const val = event.target.value;
+
+    setValue(val);
+
+    if (val === 'blur') {
+      ref?.current?.blur();
+    }
+  };
+
+  const handleClear = () => {
+    setValue('');
+  };
+
+  return (
+    <FieldText {...args} value={value} onChange={handleChange} onClear={handleClear} ref={ref} />
+  );
+};
+/** Reusable UI component for the text input */
 const meta: Meta<typeof FieldText> = {
   title: 'Field Text',
   component: FieldText,
   parameters: {
     layout: 'centered',
   },
+  argTypes: ARG_TYPES,
   tags: ['autodocs'],
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = useState('');
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const ref = useRef<HTMLInputElement>(null);
-    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-      const val = event.target.value;
-      setValue(val);
-      if (val === 'blur') {
-        ref?.current?.blur();
-      }
-    };
-
-    return <FieldText {...args} value={value} onChange={handleChange} ref={ref} />;
-  },
+  render: (args) => <FieldTextWithHooks {...args} />,
 };
 
 export default meta;
@@ -100,6 +118,20 @@ export const FullyDescribed: Story = {
 
 export const WithPassword: Story = {
   args: {
-    type: 'password',
+    type: InputType.PASSWORD,
   },
+};
+/** Collapsible text input by clicking on the icon */
+export const CollapsibleFieldText: Story = {
+  args: {
+    collapsible: true,
+    startIcon: <SearchIcon />,
+    maxLength: 256,
+    clearable: true,
+  },
+  render: (args) => (
+    <div style={{ backgroundColor: '#f7f7f8', padding: '10px' }}>
+      <FieldTextWithHooks {...args} />
+    </div>
+  ),
 };

--- a/src/components/fieldText/fieldText.test.tsx
+++ b/src/components/fieldText/fieldText.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import DefaultExport, { FieldText as NamedExport } from './index';
 import { FieldText } from './fieldText';
+import { InputType } from './types';
 
 vi.mock('@components/icons', () => ({
   ClearIcon: () => <div data-testid="mock-clear-icon">×</div>,
@@ -62,8 +63,8 @@ describe('FieldText Component', () => {
       expect(inputField).toHaveValue('Test Value');
     });
 
-    it('renders with custom type', () => {
-      render(<FieldText type="email" onChange={() => {}} />);
+    it('renders with email type', () => {
+      render(<FieldText type={InputType.EMAIL} onChange={() => {}} />);
       const inputField = screen.getByRole('textbox');
 
       expect(inputField).toHaveAttribute('type', 'email');

--- a/src/components/fieldText/fieldText.tsx
+++ b/src/components/fieldText/fieldText.tsx
@@ -16,16 +16,12 @@ import { ClearIcon, CloseEyeIcon, OpenEyeIcon } from '@components/icons';
 import { Button } from '../button';
 import { SpinLoader } from '@components/spinLoader';
 import { MaxValueDisplay } from '@components/maxValueDisplay';
+import { InputType } from './types';
 import styles from './fieldText.module.scss';
 
 const cx = classNames.bind(styles);
 
-const enum InputType {
-  PASSWORD = 'password',
-  TEXT = 'text',
-}
-
-interface FieldTextProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface FieldTextProps extends InputHTMLAttributes<HTMLInputElement> {
   value?: string;
   className?: string;
   classNameHelpText?: string;
@@ -46,7 +42,7 @@ interface FieldTextProps extends InputHTMLAttributes<HTMLInputElement> {
   onClear?: (prevValue?: string) => void;
   isRequired?: boolean;
   hasDoubleMessage?: boolean;
-  type?: string;
+  type?: InputType;
   displayError?: boolean;
   maxLengthDisplay?: number;
   collapsible?: boolean;

--- a/src/components/fieldText/stories/constants.ts
+++ b/src/components/fieldText/stories/constants.ts
@@ -1,6 +1,6 @@
 import type { ArgTypes } from '@storybook/react';
 
-import { InputType } from './types';
+import { InputType } from '../types';
 
 export const ARG_TYPES: ArgTypes = {
   title: {

--- a/src/components/fieldText/stories/fieldText.stories.tsx
+++ b/src/components/fieldText/stories/fieldText.stories.tsx
@@ -35,7 +35,7 @@ const FieldTextWithHooks: FC<FieldTextProps> = (props) => {
 };
 /** Reusable UI component for the text input */
 const meta: Meta<typeof FieldText> = {
-  title: 'Field Text',
+  title: 'Fields/Field Text',
   component: FieldText,
   parameters: {
     layout: 'centered',

--- a/src/components/fieldText/stories/fieldText.stories.tsx
+++ b/src/components/fieldText/stories/fieldText.stories.tsx
@@ -1,26 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { DeleteIcon, SearchIcon } from '@components/icons';
-import { FieldText, FieldTextProps } from './fieldText';
-import { InputType } from './types';
+import { FieldText, FieldTextProps } from '../fieldText';
+import { InputType } from '../types';
 import { ARG_TYPES } from './constants';
 import { ChangeEvent, useEffect, useRef, useState, FC } from 'react';
 
-const FieldTextWithHooks: FC<FieldTextProps> = (args) => {
-  const [value, setValue] = useState(args.value || '');
+const FieldTextWithHooks: FC<FieldTextProps> = (props) => {
+  const [value, setValue] = useState(props.value || '');
   const ref = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (args.value) {
-      setValue(args.value);
+    if (props.value) {
+      setValue(props.value);
     }
-  }, [args.value]);
+  }, [props.value]);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const val = event.target.value;
+    const { value: enteredValue } = event.target;
 
-    setValue(val);
+    setValue(enteredValue);
 
-    if (val === 'blur') {
+    if (enteredValue === 'blur') {
       ref?.current?.blur();
     }
   };
@@ -30,7 +30,7 @@ const FieldTextWithHooks: FC<FieldTextProps> = (args) => {
   };
 
   return (
-    <FieldText {...args} value={value} onChange={handleChange} onClear={handleClear} ref={ref} />
+    <FieldText {...props} value={value} onChange={handleChange} onClear={handleClear} ref={ref} />
   );
 };
 /** Reusable UI component for the text input */

--- a/src/components/fieldText/types.ts
+++ b/src/components/fieldText/types.ts
@@ -1,0 +1,5 @@
+export const enum InputType {
+  PASSWORD = 'password',
+  TEXT = 'text',
+  EMAIL = 'email',
+}

--- a/src/components/fieldTextFlex/fieldTextFlex.stories.tsx
+++ b/src/components/fieldTextFlex/fieldTextFlex.stories.tsx
@@ -3,7 +3,7 @@ import { FieldTextFlex, FieldTextFlexProps } from './fieldTextFlex';
 import { ChangeEvent, useState } from 'react';
 
 const meta: Meta<FieldTextFlexProps> = {
-  title: 'Field Text Flex',
+  title: 'Fields/Field Text Flex',
   component: FieldTextFlex,
   parameters: {
     layout: 'centered',

--- a/src/components/icons/icons.stories.tsx
+++ b/src/components/icons/icons.stories.tsx
@@ -6,7 +6,7 @@ import { CloseIcon, DeleteIcon, DropdownIcon, MinusIcon, PlusIcon, SearchIcon } 
 const icons = [CloseIcon, PlusIcon, MinusIcon, DeleteIcon, DropdownIcon, SearchIcon];
 
 const meta: Meta<typeof BaseIconButton> = {
-  title: 'Icons',
+  title: 'Icons/Icons',
   component: BaseIconButton,
   parameters: {
     layout: 'centered',

--- a/src/components/modal/modal.stories.tsx
+++ b/src/components/modal/modal.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Button } from '@components/button';
 
 const meta: Meta<typeof Modal> = {
-  title: 'Modal',
+  title: 'Modals & Notification/Modal',
   component: Modal,
   parameters: {
     layout: 'centered',

--- a/src/components/pagination/pagination.stories.tsx
+++ b/src/components/pagination/pagination.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Pagination } from './pagination';
 
 const meta: Meta<typeof Pagination> = {
-  title: 'Pagination',
+  title: 'Navigation/Pagination',
   component: Pagination,
   parameters: {
     layout: 'centered',

--- a/src/components/popover/popover.stories.tsx
+++ b/src/components/popover/popover.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Popover } from './popover';
 
 const meta: Meta<typeof Popover> = {
-  title: 'Popover',
+  title: 'Controls/Popover',
   component: Popover,
   parameters: {
     layout: 'centered',

--- a/src/components/radio/radioGroup.stories.tsx
+++ b/src/components/radio/radioGroup.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { RadioGroup } from './radioGroup';
 
 const meta: Meta<typeof RadioGroup> = {
-  title: 'Radio button',
+  title: 'Controls/Radio button',
   component: RadioGroup,
   parameters: {
     layout: 'centered',

--- a/src/components/spinLoader/spinLoader.stories.tsx
+++ b/src/components/spinLoader/spinLoader.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SpinLoader } from './spinLoader';
 
 const meta: Meta<typeof SpinLoader> = {
-  title: 'Spinner Loader',
+  title: 'Data display/Spinner Loader',
   component: SpinLoader,
   parameters: {
     layout: 'centered',

--- a/src/components/systemAlert/systemAlert.stories.tsx
+++ b/src/components/systemAlert/systemAlert.stories.tsx
@@ -3,7 +3,7 @@ import { SystemAlert } from './systemAlert';
 import { SystemAlertType } from '@components/systemAlert/types';
 
 const meta: Meta<typeof SystemAlert> = {
-  title: 'SystemAlert',
+  title: 'Modals & Notification/SystemAlert',
   component: SystemAlert,
   parameters: {
     layout: 'centered',

--- a/src/components/systemMessage/systemMessage.stories.tsx
+++ b/src/components/systemMessage/systemMessage.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SystemMessage } from './systemMessage';
 
 const meta: Meta<typeof SystemMessage> = {
-  title: 'System Message',
+  title: 'Modals & Notification/System Message',
   component: SystemMessage,
   parameters: {
     layout: 'centered',

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react';
 import { sortTableData } from '@components/table/utils';
 
 const meta: Meta<typeof Table> = {
-  title: 'Table',
+  title: 'Tables & Lists/Table',
   component: Table,
   parameters: {
     layout: 'centered',

--- a/src/components/toggle/toggle.stories.tsx
+++ b/src/components/toggle/toggle.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Toggle } from './toggle';
 
 const meta: Meta<typeof Toggle> = {
-  title: 'Toggle',
+  title: 'Controls/Toggle',
   component: Toggle,
   parameters: {
     layout: 'centered',

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -30,7 +30,7 @@ interface ContentProps {
 const Content = () => <div style={{ width: '100px', height: '100px' }}>Hello!</div>;
 
 const meta: Meta<typeof Tooltip> = {
-  title: 'Tooltip',
+  title: 'Modals & Notification/Tooltip',
   component: Tooltip,
   parameters: {
     layout: 'centered',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { resolve, join } from 'path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, LibraryFormats } from 'vite';
 import dts from 'vite-plugin-dts';
 import svgr from 'vite-plugin-svgr';
 import tsConfigPaths from 'vite-tsconfig-paths';
@@ -31,7 +31,9 @@ export default defineConfig(() => ({
     react(),
     svgr({ exportAsDefault: true }),
     tsConfigPaths(),
-    dts({ exclude: ['**/*.test.{ts,tsx}', '**/test/**', '**/*.stories.{ts,tsx}'] }),
+    dts({
+      exclude: ['**/*.test.{ts,tsx}', '**/test/**', '**/*.stories.{ts,tsx}', '**/stories/**'],
+    }),
   ],
   resolve: {
     alias: {
@@ -45,7 +47,7 @@ export default defineConfig(() => ({
     lib: {
       entry: generateEntries(),
       name: 'ui-kit',
-      formats: ['es'],
+      formats: ['es'] as LibraryFormats[],
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
VISUALS
Grouping stories by categories according to figma design. Add docs navigation, props description and types.
![image](https://github.com/user-attachments/assets/0eb8966f-9da7-41aa-b52d-72d035182464)

Add story for collapsible field text
![image](https://github.com/user-attachments/assets/a19f8e98-4823-49eb-9bcd-8672a698d11a)
![image](https://github.com/user-attachments/assets/18075195-b7e9-4dfc-8219-b5207ea69e1e)
