### PR TITLE
EPMRPP-103721 || Support content-based width for options list

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -80,10 +80,11 @@ export const Dropdown: FC<DropdownProps> = ({
       ? options.filter((option) => value.includes(option.value))
       : null;
   const { refs, floatingStyles } = useFloating({
+    placement: 'bottom-start',
     middleware: [
       offset(5),
       flip({
-        fallbackPlacements: ['bottom', 'top'],
+        fallbackPlacements: ['bottom-start', 'top-start', 'bottom', 'top'],
       }),
     ],
   });


### PR DESCRIPTION
## Changes
1. Used `isListWidthLimited` prop for supporting **dropdown options** list wider than the field itself
2. Fixed dropdown list positioning

For more details about the dropdown list appearance, see: 
https://jiraeu.epam.com/browse/EPMRPP-93474

## Visuals
Without prop:
![Screenshot 2025-06-10 113138](https://github.com/user-attachments/assets/c6073c84-76b0-4362-be10-a8ec0940bb0e)

With prop:
![Screenshot 2025-06-10 113155](https://github.com/user-attachments/assets/29339187-729a-4724-8ca8-080c3266c22d)
