### PR TITLE
Button: fix 'content' ButtonWidth style

### DIFF
--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -1,28 +1,36 @@
 ## **Button**
 
-Min width - 120px. Max width - flexible.
+A flexible button component with multiple variants and width adjustments. Default minimum width is 120px.
 
 ### Props:
 
-- **type**: _string_, optional, default = "button"
-- **disabled**: _bool_, optional, default = false
-- **variant**: _string_, optional, default = "primary"
-- **wide**: _bool_, optional, default = false
-- **icon**: _string(imported svg icon)_, optional, default = ""
-- **iconPlace**: _string('start' | 'end')_, optional, default = ""
-- **children**: _node_, optional, default= ""
-- **customClassName**: _string_, optional, default= ""
-- **dataAutomationId**: _string_, optional, default = ''
+- **type**: _'submit' | 'reset' | 'button'_, optional, default = "button"
+- **disabled**: _boolean_, optional, default = false
+- **variant**: _'primary' | 'ghost' | 'danger' | 'text'_, optional, default = "primary"
+- **adjustWidthOn**: _'content' | 'wide-content' | 'parent' | 'min-width'_, optional, default = "min-width"
+- **icon**: _ReactNode_, optional - Any React element (not just SVG icons)
+- **iconPlace**: _'start' | 'end'_, optional, default = "start"
+- **children**: _ReactNode_, optional - Button content/text
+- **className**: _string_, optional - Custom CSS class name
+- **title**: _string_, optional - Title attribute for accessibility
+- **onClick**: _MouseEventHandler<HTMLButtonElement>_, optional - Click event handler
 
 ### Events:
 
-- **onClick**
+- **onClick**: Triggered when button is clicked (disabled buttons won't trigger this)
 
 ### Variants
 
-The Button comes with variants: _primary_ (default), _ghost_, _danger_ and _text_.  
+The Button comes with variants: _primary_ (default), _ghost_, _danger_ and _text_.
+
+### Width Adjustments
+
+- **content**: Natural content width
+- **min-width**: Minimum width of 120px (default)
+- **wide-content**: Extra padding for wider appearance
+- **parent**: Full width of parent container
 
 ### Icon
 
-Only text variant can be used with icon. You can pass imported svg icon via _icon_ prop.
-_iconPlace_ prop control displaying it on the left or right respectively.
+All variants can be used with icons (not limited to text variant). You can pass any React element via the _icon_ prop.
+The _iconPlace_ prop controls whether the icon appears at the 'start' (left) or 'end' (right) of the button text.

--- a/src/components/button/button.module.scss
+++ b/src/components/button/button.module.scss
@@ -6,7 +6,6 @@
   justify-content: center;
   align-items: center;
   height: 36px;
-  min-width: 120px;
   padding: 7px 16px;
   margin: 0;
   outline: none;
@@ -113,6 +112,15 @@
 .disabled {
   opacity: var(--rp-ui-opacity-default);
   cursor: default;
+}
+
+.width-min-width {
+  min-width: 120px;
+}
+
+// Matches defaults, but defined here for CSS modules classname generation
+.width-content {
+  min-width: auto;
 }
 
 .width-wide-content {

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -15,30 +15,30 @@ export default meta;
 
 type Story = StoryObj<typeof Button>;
 
-export const Primary: Story = {
+export const Primary = {
   args: {
     variant: 'primary',
+    children: 'Primary',
   },
-  render: (args) => <Button {...args}>Primary</Button>,
-};
+} satisfies Story;
 
-export const Ghost: Story = {
+export const Ghost = {
   args: {
     variant: 'ghost',
+    children: 'Ghost',
   },
-  render: (args) => <Button {...args}>Ghost</Button>,
-};
+} satisfies Story;
 
-export const Danger: Story = {
+export const Danger = {
   args: {
     variant: 'danger',
+    children: 'Danger',
   },
-  render: (args) => <Button {...args}>Danger</Button>,
-};
+} satisfies Story;
 
-export const Text: Story = {
+export const Text = {
   args: {
     variant: 'text',
+    children: 'Text',
   },
-  render: (args) => <Button {...args}>Text</Button>,
-};
+} satisfies Story;

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -148,6 +148,14 @@ describe('Button Component', () => {
       rerender(<Button adjustWidthOn="parent">Parent Width</Button>);
       button = screen.getByRole('button');
       expect(button.className).toContain('width-parent');
+
+      rerender(<Button adjustWidthOn="content">Content Width</Button>);
+      button = screen.getByRole('button');
+      expect(button.className).toContain('width-content');
+
+      rerender(<Button adjustWidthOn="min-width">Min Width</Button>);
+      button = screen.getByRole('button');
+      expect(button.className).toContain('width-min-width');
     });
 
     it('accepts and applies custom className', () => {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,12 +1,4 @@
-import {
-  FC,
-  ReactNode,
-  ReactElement,
-  forwardRef,
-  ForwardedRef,
-  ComponentPropsWithRef,
-  MouseEventHandler,
-} from 'react';
+import { ReactNode, forwardRef, ComponentPropsWithRef, MouseEventHandler } from 'react';
 import classNames from 'classnames/bind';
 import styles from './button.module.scss';
 
@@ -14,7 +6,7 @@ const cx = classNames.bind(styles);
 
 type IconPlace = 'start' | 'end';
 type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'text';
-type ButtonWidth = 'content' | 'wide-content' | 'parent';
+type ButtonWidth = 'content' | 'wide-content' | 'parent' | 'min-width';
 
 export interface ButtonProps extends ComponentPropsWithRef<'button'> {
   children?: ReactNode;
@@ -29,17 +21,14 @@ export interface ButtonProps extends ComponentPropsWithRef<'button'> {
   variant?: ButtonVariant;
 }
 
-// TODO: Remove ts-ignore
 // DS link - https://www.figma.com/file/gjYQPbeyf4YsH3wZiVKoaj/%F0%9F%9B%A0-RP-DS-6?type=design&node-id=2350-8762&mode=design&t=GAXsAg9jOEgkVVlq-0
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-export const Button: FC<ButtonProps> = forwardRef(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       variant = 'primary',
       icon,
       iconPlace = 'start',
-      adjustWidthOn = 'content',
+      adjustWidthOn = 'min-width',
       type = 'button',
       children,
       disabled = false,
@@ -48,8 +37,8 @@ export const Button: FC<ButtonProps> = forwardRef(
       className,
       ...rest
     },
-    ref: ForwardedRef<HTMLButtonElement>,
-  ): ReactElement => {
+    ref,
+  ) => {
     const classes = cx('button', variant, className, {
       disabled,
       [`width-${adjustWidthOn}`]: adjustWidthOn,


### PR DESCRIPTION
New 'min-width' variant introduced as new default value to mantain backward-compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Button component documentation for clearer prop, event, and variant descriptions, including new and revised prop details.
- **New Features**
  - Added support for a new width adjustment option ("min-width") for Button components.
  - Introduced new props: "adjustWidthOn", "title", and "onClick".
- **Style**
  - Improved Button styling flexibility with new utility classes for width adjustments.
- **Tests**
  - Expanded test coverage for Button width adjustment options.
- **Refactor**
  - Simplified and standardized Button stories in Storybook for consistency and improved type checking.
  - Updated Button component type annotations and ref handling for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->