### PR TITLE
EPMRPP-103879 || Support optional center alignment

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -28,6 +28,7 @@ import {
   useInteractions,
   FloatingFocusManager,
   Placement,
+  ElementRects,
 } from '@floating-ui/react';
 import classNames from 'classnames/bind';
 import styles from './popover.module.scss';
@@ -72,6 +73,7 @@ interface PopoverProps {
   dataAutomationId?: string;
   isOpened?: boolean;
   setIsOpened?: (isOpened: boolean) => void;
+  isCentered?: boolean;
 }
 
 export const Popover: FC<PopoverProps> = ({
@@ -87,6 +89,7 @@ export const Popover: FC<PopoverProps> = ({
   dataAutomationId,
   isOpened,
   setIsOpened,
+  isCentered = true,
 }): ReactElement => {
   const arrowRef = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -101,6 +104,20 @@ export const Popover: FC<PopoverProps> = ({
     }
   };
 
+  const getAlignment = (rects: ElementRects, currentPlacement: Placement) => {
+    if (isCentered)
+      return (
+        ((verticalPlacements.includes(currentPlacement)
+          ? rects.reference.height
+          : rects.reference.width) -
+          TRIANGLE_WIDTH) /
+          2 -
+        arrowOffset
+      );
+
+    return -arrowOffset;
+  };
+
   const { placement, refs, floatingStyles, context } = useFloating({
     open: isPopoverOpen,
     onOpenChange,
@@ -108,13 +125,7 @@ export const Popover: FC<PopoverProps> = ({
     middleware: [
       offset(({ rects, placement: currentPlacement }) => ({
         mainAxis: safeZone + TRIANGLE_HEIGHT,
-        alignmentAxis:
-          ((verticalPlacements.includes(currentPlacement)
-            ? rects.reference.height
-            : rects.reference.width) -
-            TRIANGLE_WIDTH) /
-            2 -
-          arrowOffset,
+        alignmentAxis: getAlignment(rects, currentPlacement),
       })),
       flip({
         fallbackAxisSideDirection: 'start',

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC, ReactElement, useRef, useState, ReactNode } from 'react';
+import { FC, ReactElement, useRef, useState, ReactNode, useCallback } from 'react';
 import {
   offset,
   useFloating,
@@ -104,19 +104,22 @@ export const Popover: FC<PopoverProps> = ({
     }
   };
 
-  const getAlignment = (rects: ElementRects, currentPlacement: Placement) => {
-    if (isCentered)
-      return (
-        ((verticalPlacements.includes(currentPlacement)
-          ? rects.reference.height
-          : rects.reference.width) -
-          TRIANGLE_WIDTH) /
-          2 -
-        arrowOffset
-      );
+  const getAlignment = useCallback(
+    (rects: ElementRects, currentPlacement: Placement) => {
+      if (isCentered)
+        return (
+          ((verticalPlacements.includes(currentPlacement)
+            ? rects.reference.height
+            : rects.reference.width) -
+            TRIANGLE_WIDTH) /
+            2 -
+          arrowOffset
+        );
 
-    return -arrowOffset;
-  };
+      return -arrowOffset;
+    },
+    [arrowOffset, isCentered],
+  );
 
   const { placement, refs, floatingStyles, context } = useFloating({
     open: isPopoverOpen,


### PR DESCRIPTION
## Changes
1. Added prop `isCentered` for disabling default center alignment

## Visuals
![photo-collage png](https://github.com/user-attachments/assets/a05bdd51-523f-4070-9412-6d9595f033a2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to control the alignment of the Popover arrow with a new `isCentered` property. By default, the arrow remains centered, but users can now choose to disable this centering if desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->