### PR TITLE
EPMRPP-103879 || Make sort direction case insensitive and enum free

### DIFF
--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -47,8 +47,8 @@ Additional CSS classes to be applied to the table.
 #### `selectedRowIds` ((string | number)[], optional)
 An array containing the IDs of the currently selected rows.
 
-#### `sortingDirection` (SortDirection, optional)
-Specifies the current sorting direction ('asc' or 'desc').
+#### `sortingDirection` (SortingDirection, optional)
+Specifies the current sorting direction ('asc' | 'desc' | 'ASC' | 'DESC').
 
 #### `sortingColumn` (Column, optional)
 Specifies the column by which the table is currently sorted.

--- a/src/components/table/constants.ts
+++ b/src/components/table/constants.ts
@@ -1,0 +1,2 @@
+export const ASC = 'asc';
+export const DESC = 'desc';

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -8,6 +8,7 @@ import {
   RowData,
   SortConfig,
   SortDirection,
+  SortingDirection,
   TableComponentProps,
 } from './types';
 import { useEffect, useState } from 'react';
@@ -93,7 +94,7 @@ export const Default: Story = {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [sortingColumn, setSortingColumn] = useState<Column>(primaryColumn);
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [sortingDirection, setSortingDirection] = useState<SortDirection>(SortDirection.ASC);
+    const [sortingDirection, setSortingDirection] = useState<SortingDirection>(SortDirection.ASC);
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const defaultSortedData = sortTableData(data, sortConfig);
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -118,7 +119,10 @@ export const Default: Story = {
           onChangeSorting={(sortConfigParam = sortConfig) => {
             let { direction } = sortConfigParam;
             const { key } = sortConfigParam;
-            direction = direction === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC;
+            direction =
+              direction.toLowerCase() === SortDirection.ASC
+                ? SortDirection.DESC
+                : SortDirection.ASC;
             const sortedData = sortTableData(tableData, { key, direction });
             setSortConfig({ key, direction });
             setTableData(sortedData);

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -7,12 +7,12 @@ import {
   FixedColumn,
   RowData,
   SortConfig,
-  SortDirection,
   SortingDirection,
   TableComponentProps,
 } from './types';
 import { useEffect, useState } from 'react';
-import { sortTableData } from '@components/table/utils';
+import { sortTableData, toggleDirection } from '@components/table/utils';
+import { ASC } from './constants';
 
 const meta: Meta<typeof Table> = {
   title: 'Tables & Lists/Table',
@@ -89,12 +89,12 @@ export const Default: Story = {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [sortConfig, setSortConfig] = useState<SortConfig>({
       key: primaryColumn.key,
-      direction: SortDirection.ASC,
+      direction: ASC,
     });
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [sortingColumn, setSortingColumn] = useState<Column>(primaryColumn);
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [sortingDirection, setSortingDirection] = useState<SortingDirection>(SortDirection.ASC);
+    const [sortingDirection, setSortingDirection] = useState<SortingDirection>(ASC);
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const defaultSortedData = sortTableData(data, sortConfig);
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -119,10 +119,7 @@ export const Default: Story = {
           onChangeSorting={(sortConfigParam = sortConfig) => {
             let { direction } = sortConfigParam;
             const { key } = sortConfigParam;
-            direction =
-              direction.toLowerCase() === SortDirection.ASC
-                ? SortDirection.DESC
-                : SortDirection.ASC;
+            direction = toggleDirection(direction);
             const sortedData = sortTableData(tableData, { key, direction });
             setSortConfig({ key, direction });
             setTableData(sortedData);

--- a/src/components/table/table.test.tsx
+++ b/src/components/table/table.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import DefaultExport, { Table as NamedExport } from './index';
 import { Table } from './table';
-import { SortDirection, RowData, FixedColumn } from './types';
+import { RowData, FixedColumn } from './types';
+import { ASC, DESC } from './constants';
 
 interface CheckboxMockProps {
   value: boolean;
@@ -220,7 +221,7 @@ describe('Table Component', () => {
           sortableColumns={['name']}
           onChangeSorting={onChangeSortingMock}
           sortingColumn={mockPrimaryColumn}
-          sortingDirection={SortDirection.ASC}
+          sortingDirection={ASC}
         />,
       );
 
@@ -230,7 +231,7 @@ describe('Table Component', () => {
       expect(onChangeSortingMock).toHaveBeenCalledTimes(1);
       expect(onChangeSortingMock).toHaveBeenCalledWith({
         key: 'name',
-        direction: SortDirection.ASC,
+        direction: ASC,
       });
     });
 
@@ -251,7 +252,7 @@ describe('Table Component', () => {
           {...defaultProps}
           sortableColumns={['name']}
           sortingColumn={mockPrimaryColumn}
-          sortingDirection={SortDirection.ASC}
+          sortingDirection={ASC}
         />,
       );
 
@@ -265,7 +266,7 @@ describe('Table Component', () => {
           {...defaultProps}
           sortableColumns={['name']}
           sortingColumn={mockPrimaryColumn}
-          sortingDirection={SortDirection.DESC}
+          sortingDirection={DESC}
         />,
       );
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -79,7 +79,11 @@ export const Table: FC<TableComponentProps> = ({
   const getSortIcon = (columnKey: string) => {
     if (!sortableColumns.includes(columnKey)) return;
     if (sortingColumn?.key === columnKey) {
-      return sortingDirection === SortDirection.ASC ? <ArrowUpIcon /> : <ArrowDownIcon />;
+      return sortingDirection.toLowerCase() === SortDirection.ASC ? (
+        <ArrowUpIcon />
+      ) : (
+        <ArrowDownIcon />
+      );
     }
     return <ArrowUpIcon />;
   };

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -2,9 +2,10 @@ import { CSSProperties, useMemo, useState, FC } from 'react';
 import styles from './table.module.scss';
 import classNames from 'classnames/bind';
 import { ArrowDownIcon, ArrowUpIcon } from '@components/icons';
-import { FixedColumn, PrimaryColumn, RowData, TableComponentProps, SortDirection } from './types';
+import { FixedColumn, PrimaryColumn, RowData, TableComponentProps } from './types';
 import { Checkbox } from '@components/checkbox';
-import { getColumnsKeys } from './utils';
+import { getColumnsKeys, isAsc } from './utils';
+import { ASC } from './constants';
 
 const cx = classNames.bind(styles);
 
@@ -18,7 +19,7 @@ export const Table: FC<TableComponentProps> = ({
   headerClassName = '',
   selectable = false,
   selectedRowIds = [],
-  sortingDirection = SortDirection.ASC,
+  sortingDirection = ASC,
   sortingColumn = primaryColumn,
   sortableColumns = getColumnsKeys([primaryColumn, ...fixedColumns]),
   onChangeSorting = () => {},
@@ -79,11 +80,7 @@ export const Table: FC<TableComponentProps> = ({
   const getSortIcon = (columnKey: string) => {
     if (!sortableColumns.includes(columnKey)) return;
     if (sortingColumn?.key === columnKey) {
-      return sortingDirection.toLowerCase() === SortDirection.ASC ? (
-        <ArrowUpIcon />
-      ) : (
-        <ArrowDownIcon />
-      );
+      return isAsc(sortingDirection) ? <ArrowUpIcon /> : <ArrowDownIcon />;
     }
     return <ArrowUpIcon />;
   };

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -31,9 +31,10 @@ export enum SortDirection {
   ASC = 'asc',
   DESC = 'desc',
 }
+export type SortingDirection = 'asc' | 'desc' | 'ASC' | 'DESC';
 export interface SortConfig {
   key: string;
-  direction: SortDirection;
+  direction: SortingDirection;
 }
 export interface TableComponentProps {
   data: RowData[];
@@ -45,7 +46,7 @@ export interface TableComponentProps {
   headerClassName?: string;
   rowClassName?: string;
   selectedRowIds?: (string | number)[];
-  sortingDirection?: SortDirection;
+  sortingDirection?: SortingDirection;
   sortingColumn?: Column;
   sortableColumns?: string[];
   onChangeSorting?: (sortConfig?: SortConfig) => void;

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { ASC, DESC } from './constants';
 
 export interface Column {
   key: string;
@@ -27,11 +28,7 @@ export interface RowData {
   rowConfigs?: RowConfigs;
   metaData?: MetaData;
 }
-export enum SortDirection {
-  ASC = 'asc',
-  DESC = 'desc',
-}
-export type SortingDirection = 'asc' | 'desc' | 'ASC' | 'DESC';
+export type SortingDirection = typeof ASC | typeof DESC | Uppercase<typeof ASC | typeof DESC>;
 export interface SortConfig {
   key: string;
   direction: SortingDirection;

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -7,10 +7,10 @@ export const sortTableData = (tableData: RowData[], sortConfig?: SortConfig): Ro
       const contentB = b[sortConfig.key].content || b[sortConfig.key];
       console.log(contentA, contentB);
       if (contentA < contentB) {
-        return sortConfig.direction === SortDirection.ASC ? -1 : 1;
+        return sortConfig.direction.toLowerCase() === SortDirection.ASC ? -1 : 1;
       }
       if (contentA > contentB) {
-        return sortConfig.direction === SortDirection.ASC ? 1 : -1;
+        return sortConfig.direction.toLowerCase() === SortDirection.ASC ? 1 : -1;
       }
       return 0;
     });

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -1,16 +1,21 @@
-import { Column, RowData, SortConfig, SortDirection } from './types';
+import { ASC, DESC } from './constants';
+import { Column, RowData, SortConfig, SortingDirection } from './types';
+
+export const isAsc = (direction: SortingDirection) => {
+  return direction.toLowerCase() === ASC;
+};
 
 export const sortTableData = (tableData: RowData[], sortConfig?: SortConfig): RowData[] => {
   if (sortConfig) {
     tableData.sort((a, b) => {
       const contentA = a[sortConfig.key].content || a[sortConfig.key];
       const contentB = b[sortConfig.key].content || b[sortConfig.key];
-      console.log(contentA, contentB);
+
       if (contentA < contentB) {
-        return sortConfig.direction.toLowerCase() === SortDirection.ASC ? -1 : 1;
+        return isAsc(sortConfig.direction) ? -1 : 1;
       }
       if (contentA > contentB) {
-        return sortConfig.direction.toLowerCase() === SortDirection.ASC ? 1 : -1;
+        return isAsc(sortConfig.direction) ? 1 : -1;
       }
       return 0;
     });
@@ -20,4 +25,8 @@ export const sortTableData = (tableData: RowData[], sortConfig?: SortConfig): Ro
 
 export const getColumnsKeys = (columns: Column[]): string[] => {
   return columns.map((column) => column.key);
+};
+
+export const toggleDirection = (direction: SortingDirection) => {
+  return isAsc(direction) ? DESC : ASC;
 };


### PR DESCRIPTION
## Changes

1. Replaced the `SortDirection` enum with a `SortingDirection` string union type (`'asc' | 'desc' | 'ASC' | 'DESC'`).
2. Added support for uppercase values (`'ASC'`, `'DESC'`).

## Motivation

Using an enum tightly couples the component to a specific implementation and restricts inputs to only the enum values. This makes the component harder to reuse and requires consumers to import the enum just to pass common values like `'asc'` or `'desc'`.
_Screenshot:_
![Screenshot 2025-06-19 145859](https://github.com/user-attachments/assets/dcc8101d-14ad-476e-ab64-67c52aa685d0)

**Conclusion:** Switching to a plain union type improves flexibility and allows passing standard string values without relying on the enum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved sorting functionality in tables to handle both uppercase and lowercase sorting directions, ensuring consistent behavior regardless of input format.
- **New Features**
	- Expanded support for sorting direction values, allowing both 'asc'/'desc' and 'ASC'/'DESC' formats.
- **Refactor**
	- Unified sorting direction handling using constants and utility functions for toggling and checking sort order.
	- Updated table component and related tests to use new sorting direction constants and types.
- **Documentation**
	- Updated table component documentation to reflect expanded sorting direction value options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->