### PR TITLE
EPMRPP-92258 || Set default min-width for buttons in modals

### DIFF
--- a/src/components/modal/modalFooter/modalFooter.tsx
+++ b/src/components/modal/modalFooter/modalFooter.tsx
@@ -30,7 +30,7 @@ export const ModalFooter: FC<ModalFooterProps> = ({
           <div className={cx('button-container')}>
             <Button
               variant="ghost"
-              adjustWidthOn={size === 'small' ? 'parent' : 'content'}
+              adjustWidthOn={size === 'small' ? 'parent' : 'min-width'}
               onClick={closeHandler}
               {...cancelButton}
             />
@@ -38,7 +38,7 @@ export const ModalFooter: FC<ModalFooterProps> = ({
         )}
         {okButton && (
           <div className={cx('button-container')}>
-            <Button adjustWidthOn={size === 'small' ? 'parent' : 'content'} {...okButton} />
+            <Button adjustWidthOn={size === 'small' ? 'parent' : 'min-width'} {...okButton} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Changes
The `min-width` is set for regular-size modal window buttons. As we have **min-width = 120px** for buttons in all modals:
[RP6-Organizations Modals Design](https://www.figma.com/design/KCbLCWSbQErmRcOFVxnNj3/RP6-Organizations?node-id=8396-52649&t=bckn2Ksv3Wxc9PDp-0) 

## Visuals
![Screenshot 2025-06-26 094302](https://github.com/user-attachments/assets/f13167f0-38a6-477c-be77-84328101bcba)
![Screenshot 2025-06-26 094320](https://github.com/user-attachments/assets/5b897ced-feca-4704-90c5-25f0e397038b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated button width adjustment behavior in modal footers for improved consistency across different modal sizes. No changes to the appearance for small-sized modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->