### PR TITLE
EPMRPP-93349 || Remove background in disabled ghost dropdown

### DIFF
--- a/src/components/dropdown/dropdown.module.scss
+++ b/src/components/dropdown/dropdown.module.scss
@@ -149,6 +149,10 @@ $Z-INDEX-POPUP: 10;
   border-color: transparent;
   background: transparent;
 
+  &.disabled {
+    background: transparent;
+  }
+
   &:hover:not(:active):not(:focus-visible):not(.opened):not(.error) {
     border-color: transparent;
   }


### PR DESCRIPTION
## Changes
- Removed background in `disabled` `ghost` dropdown according to the design

[DS: Disabled Ghost Dropdown](https://www.figma.com/design/G0UwEwSjuFKXrVvNa0Duw3/%E2%9A%A1%EF%B8%8F-RP-Design-System-6?node-id=13266-8629&t=lvPEmR6n0Sdq94T1-4)  
[DS: Example of usage](https://www.figma.com/design/KCbLCWSbQErmRcOFVxnNj3/RP6-Organizations?node-id=8463-61443&t=CDISeBM7L7nJWEdC-4)
<img width="186" height="100" alt="image" src="https://github.com/user-attachments/assets/3ead7974-e57e-44b3-a8d3-251bb2056ca1" />

## Visuals
Before and After
<img width="180" height="135" alt="photo-collage png (2)" src="https://github.com/user-attachments/assets/dec1bfbd-f80a-43fe-89ce-b16b36342a31" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styles to ensure that disabled ghost elements have a transparent background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->