### PR TITLE
EPMRPP-93349 || Remove left and right paddings in ghost dropdown

### DIFF
--- a/src/components/dropdown/dropdown.module.scss
+++ b/src/components/dropdown/dropdown.module.scss
@@ -148,6 +148,7 @@ $Z-INDEX-POPUP: 10;
 .ghost {
   border-color: transparent;
   background: transparent;
+  padding: 9px 0 7px;
 
   &.disabled {
     background: transparent;
@@ -165,6 +166,11 @@ $Z-INDEX-POPUP: 10;
     .value {
       color: var(--rp-ui-color-primary-pressed);
     }
+  }
+
+  &:active,
+  &:focus-visible {
+    padding: 7px 0;
   }
 }
 


### PR DESCRIPTION
## Changes
- Removed left and right paddings in `ghost` dropdown

[DS Link](https://www.figma.com/design/G0UwEwSjuFKXrVvNa0Duw3/%E2%9A%A1%EF%B8%8F-RP-Design-System-6?node-id=13266-8636&t=HPwcMJak9nIV8bH2-4) 
<img width="228" height="86" alt="image" src="https://github.com/user-attachments/assets/61e9519e-d106-4420-b828-545130c6171f" />

## Visuals
Before and After
<img width="180" height="135" alt="photo-collage png (3)" src="https://github.com/user-attachments/assets/0400706d-bc05-4061-a45f-f92befb679aa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dropdown styling to provide consistent vertical padding for ghost elements, with dynamic adjustments when active or focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->