### PR TITLE
EPMRPP-105687 || Prevent input blur on Clear button click

### DIFF
--- a/src/components/fieldText/fieldText.tsx
+++ b/src/components/fieldText/fieldText.tsx
@@ -210,7 +210,12 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
           )}
           {clearable && value.length > 0 && (
             <span className={cx('icon-container-end')}>
-              <button type="button" className={cx('clear-icon', { disabled })} onClick={clearInput}>
+              <button
+                type="button"
+                className={cx('clear-icon', { disabled })}
+                onClick={clearInput}
+                onMouseDown={(e) => e.preventDefault()}
+              >
                 <ClearIcon />
               </button>
             </span>


### PR DESCRIPTION
## Changes
- Calling `event.preventDefault()` on `onMouseDown` for the clear button prevents input blur

## Motivation
When clicking the clear (`×`) button inside the input, the field was losing focus, which unintentionally triggered redux-form validation. This led to a poor UX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the clear button in text fields to prevent unintended behavior when clicking, ensuring a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->