### PR TITLE
EPMRPP-96061 || Implement additional Danger buttons

### DIFF
--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -6,7 +6,7 @@ A flexible button component with multiple variants and width adjustments. Defaul
 
 - **type**: _'submit' | 'reset' | 'button'_, optional, default = "button"
 - **disabled**: _boolean_, optional, default = false
-- **variant**: _'primary' | 'ghost' | 'danger' | 'text'_, optional, default = "primary"
+- **variant**: _'primary' | 'ghost' | 'danger' | 'text' | 'ghost-danger' | 'text-danger'_, optional, default = "primary"
 - **adjustWidthOn**: _'content' | 'wide-content' | 'parent' | 'min-width'_, optional, default = "min-width"
 - **icon**: _ReactNode_, optional - Any React element (not just SVG icons)
 - **iconPlace**: _'start' | 'end'_, optional, default = "start"
@@ -21,7 +21,14 @@ A flexible button component with multiple variants and width adjustments. Defaul
 
 ### Variants
 
-The Button comes with variants: _primary_ (default), _ghost_, _danger_ and _text_.
+The Button comes with variants: _primary_ (default), _ghost_, _danger_, _text_, _ghost-danger_, and _text-danger_.
+
+- **primary**: Solid background with primary color
+- **ghost**: Transparent background with primary color border and text
+- **danger**: Solid background with error/danger color
+- **text**: Text-only button with no background or border
+- **ghost-danger**: Transparent background with error/danger color border and text
+- **text-danger**: Text-only button with error/danger color
 
 ### Width Adjustments
 

--- a/src/components/button/button.module.scss
+++ b/src/components/button/button.module.scss
@@ -81,7 +81,7 @@
   min-width: auto;
   height: auto;
   border: 0;
-  padding: 0;
+  padding: 2px 0px 0px;
   background: none;
   line-height: 22px;
   color: var(--rp-ui-color-primary-text);
@@ -98,6 +98,7 @@
     }
   }
   &:focus:not(.disabled, :active) {
+    border: 2px solid var(--rp-ui-color-primary-focused);
     color: var(--rp-ui-color-primary-focused);
     svg * {
       fill: var(--rp-ui-color-primary-focused);
@@ -105,6 +106,54 @@
   }
   svg * {
     fill: var(--rp-ui-color-primary-text);
+  }
+}
+
+.ghost-danger {
+  border: 1px solid var(--rp-ui-color-error);
+  background-color: transparent;
+  color: var(--rp-ui-color-error);
+  &:hover:not(.disabled) {
+    border: 1px solid var(--rp-ui-color-error-hover);
+    color: var(--rp-ui-color-error-hover);
+  }
+  &:active:not(.disabled) {
+    border: 1px solid var(--rp-ui-color-error-pressed);
+    color: var(--rp-ui-color-error-pressed);
+  }
+  &:focus:not(.disabled, :active) {
+    border: 2px solid var(--rp-ui-color-error-focused);
+  }
+  svg * {
+    fill: var(--rp-ui-color-error);
+  }
+}
+
+.text-danger {
+  min-width: auto;
+  height: auto;
+  border: 0;
+  padding: 2px 0px 0px;
+  background: none;
+  line-height: 22px;
+  color: var(--rp-ui-color-error);
+  &:hover:not(.disabled) {
+    color: var(--rp-ui-color-error-hover);
+    svg * {
+      fill: var(--rp-ui-color-error-hover);
+    }
+  }
+  &:active:not(.disabled) {
+    color: var(--rp-ui-color-error-pressed);
+    svg * {
+      fill: var(--rp-ui-color-error-pressed);
+    }
+  }
+  &:focus:not(.disabled, :active) {
+    border: 2px solid var(--rp-ui-color-error-focused);
+  }
+  svg * {
+    fill: var(--rp-ui-color-error);
   }
 }
 

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from './button';
+import { PlusIcon, EditIcon, DeleteIcon, SearchIcon, MinusIcon } from '../icons';
 
 const meta: Meta<typeof Button> = {
   title: 'Buttons/Button',
@@ -40,5 +41,73 @@ export const Text = {
   args: {
     variant: 'text',
     children: 'Text',
+  },
+} satisfies Story;
+
+export const GhostDanger = {
+  args: {
+    variant: 'ghost-danger',
+    children: 'Ghost Danger',
+  },
+} satisfies Story;
+
+export const TextDanger = {
+  args: {
+    variant: 'text-danger',
+    children: 'Text Danger',
+  },
+} satisfies Story;
+
+export const WithLeftIcon = {
+  args: {
+    variant: 'primary',
+    children: 'Add Item',
+    icon: <PlusIcon />,
+    iconPlace: 'start',
+  },
+} satisfies Story;
+
+export const WithRightIcon = {
+  args: {
+    variant: 'ghost',
+    children: 'Edit',
+    icon: <EditIcon />,
+    iconPlace: 'end',
+  },
+} satisfies Story;
+
+export const DangerWithIcon = {
+  args: {
+    variant: 'danger',
+    children: 'Delete',
+    icon: <DeleteIcon />,
+    iconPlace: 'start',
+  },
+} satisfies Story;
+
+export const TextWithIcon = {
+  args: {
+    variant: 'text',
+    children: 'Search',
+    icon: <SearchIcon />,
+    iconPlace: 'end',
+  },
+} satisfies Story;
+
+export const GhostDangerWithIcon = {
+  args: {
+    variant: 'ghost-danger',
+    children: 'Remove',
+    icon: <DeleteIcon />,
+    iconPlace: 'start',
+  },
+} satisfies Story;
+
+export const TextDangerWithIcon = {
+  args: {
+    variant: 'text-danger',
+    children: 'Remove Item',
+    icon: <MinusIcon />,
+    iconPlace: 'end',
   },
 } satisfies Story;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -5,7 +5,7 @@ import styles from './button.module.scss';
 const cx = classNames.bind(styles);
 
 type IconPlace = 'start' | 'end';
-type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'text';
+type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'text' | 'ghost-danger' | 'text-danger';
 type ButtonWidth = 'content' | 'wide-content' | 'parent' | 'min-width';
 
 export interface ButtonProps extends ComponentPropsWithRef<'button'> {


### PR DESCRIPTION
## Changes
1. Implemented two additional varians of buttons: `ghost-danger` and `text-danger`
2. Fixed paddings and focused state for `text` button

## Links
[DS: Buttons](https://www.figma.com/design/G0UwEwSjuFKXrVvNa0Duw3/%E2%9A%A1%EF%B8%8F-RP-Design-System-6?node-id=798-1013&t=wxuhtJ6A8mV2rfPA-4)  

<img width="469" height="259" alt="image" src="https://github.com/user-attachments/assets/d8d3dd8e-dbfb-4767-b8c5-06166ae2245a" />

## Visuals
<img width="180" height="135" alt="photo-collage png (5)" src="https://github.com/user-attachments/assets/392ffc55-6b57-4d14-aac9-d2253c4c9f87" />
<img width="180" height="135" alt="photo-collage png (6)" src="https://github.com/user-attachments/assets/a894f888-a410-4b85-a6a9-595477e0f0f0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new button variants: "ghost-danger" and "text-danger," providing additional styling options for error or danger actions.
  * Expanded Storybook examples to showcase the new variants and demonstrate button usage with icons in various positions.

* **Style**
  * Updated button styles to support the new variants, including distinct hover, active, and focus states for "ghost-danger" and "text-danger."
  * Improved focus styling for text buttons.

* **Documentation**
  * Updated Button component documentation to include and describe all six available variants, including the new "ghost-danger" and "text-danger" options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->