### PR TITLE
EPMRPP-96061 || Update text button state

### DIFF
--- a/src/components/button/button.module.scss
+++ b/src/components/button/button.module.scss
@@ -99,10 +99,6 @@
   }
   &:focus:not(.disabled, :active) {
     border: 2px solid var(--rp-ui-color-primary-focused);
-    color: var(--rp-ui-color-primary-focused);
-    svg * {
-      fill: var(--rp-ui-color-primary-focused);
-    }
   }
   svg * {
     fill: var(--rp-ui-color-primary-text);


### PR DESCRIPTION
## Changes
1. Removed the color and SVG-fill for a focused `text` button

## Links
[DS: Text button focused](https://www.figma.com/design/G0UwEwSjuFKXrVvNa0Duw3/%E2%9A%A1%EF%B8%8F-RP-Design-System-6?node-id=798-1067&t=KPwu3AQTrrL0ZBTj-4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the focus state of text buttons to remove changes to text and icon colors, now highlighting focus with only a border color change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->