### PR TITLE
EPMRPP-103631 || Fix FieldTextFlex focus

### DIFF
--- a/src/components/fieldTextFlex/fieldTextFlex.module.scss
+++ b/src/components/fieldTextFlex/fieldTextFlex.module.scss
@@ -29,7 +29,7 @@
 
   &:focus:not(.error.touched) {
     border: 1px solid var(--rp-ui-color-primary-focused);
-    box-shadow: 0 0 0 1px var(--rp-ui-color-primary-focused);
+    box-shadow: inset 0 0 0 1px var(--rp-ui-color-primary-focused);
   }
 
   &.error.touched {


### PR DESCRIPTION
## Changes
1. Fixed the `FieldTextFlex` focus.
The bug has been found here:
<img width="494" height="605" alt="Screenshot 2025-08-12 162506" src="https://github.com/user-attachments/assets/d94d3dd2-09f0-4834-833f-4091845c8c2f" />
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated focus appearance for text fields/text areas: the focus indicator now appears inside the field rather than outside.
  * Border thickness remains unchanged; only the focus highlight positioning is adjusted.
  * Users may notice a different visual emphasis when focusing inputs, with the highlight contained within the field’s area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->