### PR TITLE
EPMRPP-106688 || Eye icon placement in Password field is incorrect

### DIFF
--- a/src/components/fieldText/fieldText.tsx
+++ b/src/components/fieldText/fieldText.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react';
 import classNames from 'classnames/bind';
 import { ClearIcon, CloseEyeIcon, OpenEyeIcon } from '@components/icons';
-import { Button } from '../button';
+import { BaseIconButton } from '../baseIconButton';
 import { SpinLoader } from '@components/spinLoader';
 import { MaxValueDisplay } from '@components/maxValueDisplay';
 import { FieldLabel } from '@components/fieldLabel';
@@ -179,9 +179,7 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
               {...rest}
             />
             {type === 'password' && value && (
-              <Button
-                icon={passwordVisible ? <OpenEyeIcon /> : <CloseEyeIcon />}
-                variant={'text'}
+              <BaseIconButton
                 className={cx('eye-icon')}
                 onMouseDown={showPassword}
                 onMouseLeave={hidePassword}
@@ -189,7 +187,9 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
                 onTouchStart={showPassword}
                 onTouchEnd={hidePassword}
                 onTouchCancel={hidePassword}
-              />
+              >
+                {passwordVisible ? <OpenEyeIcon /> : <CloseEyeIcon />}
+              </BaseIconButton>
             )}
             {placeholder && !value && (
               <span className={cx('placeholder')}>


### PR DESCRIPTION
## Changes
1. Replaced the Button component with the BaseIconButton to support states and correct width of the icon

## Visuals
<img width="274" height="70" alt="Screenshot 2025-09-02 123520" src="https://github.com/user-attachments/assets/5383cc06-3d0b-4e76-a9ed-c3b1768dbe52" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the password visibility toggle to use an icon-only button for a more streamlined implementation, with no change to behavior.
* **Style**
  * Minor visual adjustments to the password visibility control; the eye icon is now rendered directly within the button for a cleaner, more consistent look.
* **Accessibility**
  * Improved consistency of the interactive control, which may enhance focus and interaction patterns without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->