### PR TITLE
EPMRPP-107019 || The next year value is not displayed in the field

### DIFF
--- a/src/components/datePicker/header/datePickerHeader.tsx
+++ b/src/components/datePicker/header/datePickerHeader.tsx
@@ -61,7 +61,7 @@ export const DatePickerHeader: FC<DatePickerHeaderProps> = ({
         acc.concat({ value: yearValue, label: `${yearValue}` }),
       [],
     );
-  }, [yearsOptions]);
+  }, [yearsOptions, year]);
 
   const onMonthChange = (changedMonth: DropdownValue | DropdownValue[]) => {
     const numberMonth: number = changedMonth as number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date picker’s year dropdown now updates correctly when the current date changes (e.g., when navigating months/years).
  * Prevents stale or incorrect year options when a custom list isn’t provided, ensuring the dropdown reflects the appropriate year range.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->