### PR TITLE
Fix storybook build not displaying font weight properly

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,6 +15,7 @@ const config: StorybookConfig = {
   docs: {
     autodocs: 'tag',
   },
+  staticDirs: ['../public'],
   managerHead: (head) => `
     ${head}
     <meta name="robots" content="noindex" />

--- a/src/assets/styles/fonts/open-sans.scss
+++ b/src/assets/styles/fonts/open-sans.scss
@@ -6,7 +6,7 @@
   font-display: swap;
   font-style: normal;
   src: local('Open Sans Light'), local('OpenSans-Light'),
-  url('./fonts/OpenSans/OpenSans-Light.ttf') format('truetype');
+  url('/fonts/OpenSans/OpenSans-Light.ttf') format('truetype');
 }
 
 @font-face {
@@ -15,7 +15,7 @@
   font-display: swap;
   font-style: normal;
   src: local('Open Sans Regular'), local('OpenSans-Regular'),
-  url('./fonts/OpenSans/OpenSans-Regular.ttf') format('truetype');
+  url('/fonts/OpenSans/OpenSans-Regular.ttf') format('truetype');
 }
 
 @font-face {
@@ -24,7 +24,7 @@
   font-display: swap;
   font-style: normal;
   src: local('Open Sans Medium'), local('OpenSans-Medium'),
-  url('./fonts/OpenSans/OpenSans-Medium.ttf') format('truetype');
+  url('/fonts/OpenSans/OpenSans-Medium.ttf') format('truetype');
 }
 
 @font-face {
@@ -33,7 +33,7 @@
   font-display: swap;
   font-style: normal;
   src: local('Open Sans Semibold'), local('OpenSans-Semibold'),
-  url('./fonts/OpenSans/OpenSans-Semibold.ttf') format('truetype');
+  url('/fonts/OpenSans/OpenSans-Semibold.ttf') format('truetype');
 }
 
 @font-face {
@@ -42,5 +42,5 @@
   font-display: swap;
   font-style: normal;
   src: local('Open Sans Bold'), local('OpenSans-Bold'),
-  url('./fonts/OpenSans/OpenSans-Bold.ttf') format('truetype');
+  url('/fonts/OpenSans/OpenSans-Bold.ttf') format('truetype');
 }

--- a/src/assets/styles/fonts/roboto.scss
+++ b/src/assets/styles/fonts/roboto.scss
@@ -5,8 +5,7 @@
   font-weight: $fw-regular;
   font-display: swap;
   font-style: normal;
-  src: local('Roboto Regular'), local('Roboto-Regular'),
-  url('./fonts/Roboto/Roboto-Regular.ttf') format('truetype');
+  src: url('/fonts/Roboto/Roboto-Regular.ttf') format('truetype');
 }
 
 @font-face {
@@ -14,8 +13,7 @@
   font-weight: $fw-medium;
   font-display: swap;
   font-style: normal;
-  src: local('Roboto Medium'), local('Roboto-Medium'),
-  url('./fonts/Roboto/Roboto-Medium.ttf') format('truetype');
+  src: url('/fonts/Roboto/Roboto-Medium.ttf') format('truetype');
 }
 
 @font-face {
@@ -23,6 +21,5 @@
   font-weight: $fw-bold;
   font-display: swap;
   font-style: normal;
-  src: local('Roboto-Bold'), local('Roboto-Bold'),
-  url('./fonts/Roboto/Roboto-Bold.ttf') format('truetype');
+  src: url('/fonts/Roboto/Roboto-Bold.ttf') format('truetype');
 }


### PR DESCRIPTION
Storybook build version was ignoring `font-weight: 500` rule and was rendering it as `font-weight: 400`

The built CSS pointed fonts to a wrong path. In build, styles are under /assets, but previous url('./fonts/...') resolved to /assets/fonts/... (doesn’t exist). Dev server masked this; build didn’t. Switching to absolute url('/fonts/...') fixed it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured fonts load reliably across environments by switching Open Sans and Roboto sources to root-based URLs and removing local() fallbacks for Roboto. Improves consistent typography and reduces missing-font issues.

* **Chores**
  * Updated Storybook to serve static assets from the public directory, ensuring fonts and other assets render correctly in stories and during local previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->