### PR TITLE
add warning state to system alert

### DIFF
--- a/src/components/systemAlert/systemAlert.module.scss
+++ b/src/components/systemAlert/systemAlert.module.scss
@@ -10,6 +10,12 @@
   justify-content: space-between;
   box-shadow: var(--rp-ui-base-shadow-secondary);
 
+  &--black {
+    svg path {
+      fill: var(--rp-ui-base-almost-black) !important;
+    }
+  }
+
   &.error {
     background-color: var(--rp-ui-base-sm-error);
   }
@@ -20,6 +26,10 @@
 
   &.info {
     background-color: var(--rp-ui-base-no-defect-bug-group);
+  }
+
+  &.warning {
+    background-color: var(--rp-ui-base-defect-type-AB);
   }
 
   .icon-wrapper {
@@ -40,12 +50,19 @@
       font-family: var(--rp-ui-base-font-family);
       @include font-scale(x2-medium);
       font-weight: var(--rp-ui-base-fw-semi-bold);
-      color: var(--rp-ui-base-bg-000);
       display: -webkit-box;
       max-width: 100%;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       overflow: hidden;
+
+      &--white {
+        color: var(--rp-ui-base-bg-000);
+      }
+
+      &--black {
+        color: var(--rp-ui-base-almost-black);
+      }
     }
   }
 

--- a/src/components/systemAlert/systemAlert.stories.tsx
+++ b/src/components/systemAlert/systemAlert.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { SystemAlert } from './systemAlert';
-import { SystemAlertType } from '@components/systemAlert/types';
+import { SystemAlertType, SystemAlertTypographyColorType } from '@components/systemAlert/types';
 
 const meta: Meta<typeof SystemAlert> = {
   title: 'Modals & Notification/SystemAlert',
@@ -9,6 +9,18 @@ const meta: Meta<typeof SystemAlert> = {
     layout: 'centered',
   },
   tags: ['autodocs'],
+  argTypes: {
+    type: {
+      options: ['info', 'success', 'warning', 'error'],
+      control: 'radio',
+      table: { type: { summary: 'string' } },
+    },
+    typographyColor: {
+      options: ['white', 'black'],
+      control: 'radio',
+      table: { type: { summary: 'string' } },
+    },
+  },
   args: {
     title: 'Ab dignissimos exercitationem laudantium magni voluptas.',
     onClose: () => {},
@@ -22,7 +34,19 @@ type Story = StoryObj<typeof SystemAlert>;
 
 export const Default: Story = {
   render: (args) => (
-    <div style={{ minHeight: '500px', padding: '200px' }}>
+    <div style={{ minHeight: '150px', padding: '50px' }}>
+      <SystemAlert {...args}></SystemAlert>
+    </div>
+  ),
+};
+
+export const Warning: Story = {
+  args: {
+    type: SystemAlertType.WARNING,
+    typographyColor: SystemAlertTypographyColorType.BLACK,
+  },
+  render: (args) => (
+    <div style={{ minHeight: '150px', padding: '50px' }}>
       <SystemAlert {...args}></SystemAlert>
     </div>
   ),

--- a/src/components/systemAlert/systemAlert.tsx
+++ b/src/components/systemAlert/systemAlert.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactElement, useEffect, useRef, useState } from 'react';
-import { SystemAlertProps, SystemAlertType } from './types';
+import { SystemAlertProps, SystemAlertType, SystemAlertTypographyColorType } from './types';
 import styles from './systemAlert.module.scss';
 import classNames from 'classnames/bind';
 import { CloseIcon, ErrorIcon, InfoIcon, SuccessIcon } from '@components/icons';
@@ -13,6 +13,7 @@ export const SystemAlert: FC<SystemAlertProps> = ({
   onClose,
   icon = null,
   type = SystemAlertType.INFO,
+  typographyColor = SystemAlertTypographyColorType.WHITE,
   duration = DEFAULT_DURATION,
   className,
   dataAutomationId,
@@ -43,6 +44,7 @@ export const SystemAlert: FC<SystemAlertProps> = ({
         return <InfoIcon />;
       case 'success':
         return <SuccessIcon />;
+      case 'warning':
       case 'error':
         return <ErrorIcon />;
       default:
@@ -52,13 +54,13 @@ export const SystemAlert: FC<SystemAlertProps> = ({
 
   return (
     <div
-      className={cx('system-alert', type, className)}
+      className={cx('system-alert', type, className, `system-alert--${typographyColor}`)}
       title={systemTitle}
       data-automation-id={dataAutomationId}
     >
       <div className={cx('icon-wrapper')}>{getIcon()}</div>
       <div className={cx('content-wrapper')}>
-        <h2 ref={refSystemAlert} className={cx('title')}>
+        <h2 ref={refSystemAlert} className={cx('title', `title--${typographyColor}`)}>
           {title}
         </h2>
       </div>

--- a/src/components/systemAlert/types.ts
+++ b/src/components/systemAlert/types.ts
@@ -2,13 +2,20 @@ import { ReactElement } from 'react';
 export enum SystemAlertType {
   INFO = 'info',
   SUCCESS = 'success',
+  WARNING = 'warning',
   ERROR = 'error',
+}
+
+export enum SystemAlertTypographyColorType {
+  WHITE = 'white',
+  BLACK = 'black',
 }
 export interface SystemAlertProps {
   title: string;
   onClose: () => void;
   icon?: ReactElement | null;
   type?: SystemAlertType;
+  typographyColor?: SystemAlertTypographyColorType;
   duration?: number;
   className?: string;
   dataAutomationId?: string;


### PR DESCRIPTION
<img width="1909" height="855" alt="image" src="https://github.com/user-attachments/assets/aa27c24e-f36a-4809-a009-0ee0e0161ea2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Warning alert type.
  - Introduced configurable alert text color (white or black) for better contrast; icons adjust accordingly.
  - Refined alert styling for improved readability.
- Documentation
  - Storybook now includes controls to switch alert type and text color.
  - Added a Warning example in Storybook and simplified the preview layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->