### PR TITLE
EPMRPP-107731 || Modal. Add ability to show tooltip on OK button

### DIFF
--- a/src/components/modal/README.md
+++ b/src/components/modal/README.md
@@ -2,7 +2,7 @@
 
 Default width - 480px, height 100%
 
-> okButton format (see Button)
+> okButton format (see Button) - supports tooltipNode for displaying tooltips
 
 > cancelButton (see Button)
 
@@ -11,7 +11,7 @@ Default width - 480px, height 100%
 - **title**: _string_, optional, default = ""
 - **children**: _node_, optional, default = null
 - **footerNode**: _node_, optional, default = null
-- **okButton**: _object_, optional, default = null
+- **okButton**: _object_, optional, default = null (supports **tooltipNode**: _ReactNode_)
 - **cancelButton**: _object_, optional, default = null
 - **className**: _string_, optional, default = ""
 - **size**: _string_, optional, default = "default"

--- a/src/components/modal/modal.stories.tsx
+++ b/src/components/modal/modal.stories.tsx
@@ -213,3 +213,17 @@ export const ScrollableWithoutFooter: Story = {
     ),
   },
 };
+
+export const WithTooltipOnOkButton: Story = {
+  args: {
+    title: 'Modal with tooltip on OK button',
+    children: 'Hover over the OK button to see the tooltip.',
+    okButton: {
+      children: 'Save',
+      tooltipNode: 'This will save all your changes to the database',
+    },
+    cancelButton: {
+      children: 'Cancel',
+    },
+  },
+};

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -8,6 +8,7 @@ import { ButtonProps } from '@components/button';
 import { ModalContent } from './modalContent';
 import { ModalFooter, ModalSize } from './modalFooter';
 import { ModalHeader } from './modalHeader';
+import { ExtendedButtonProps } from './types';
 import styles from './modal.module.scss';
 
 const cx = classNames.bind(styles);
@@ -30,7 +31,7 @@ interface ModalProps {
   size?: ModalSize;
   overlay?: ModalOverlay;
   allowCloseOutside?: boolean;
-  okButton?: ButtonProps;
+  okButton?: ExtendedButtonProps;
   cancelButton?: ButtonProps;
   scrollable?: boolean;
   withoutFooter?: boolean;

--- a/src/components/modal/modalFooter/modalFooter.tsx
+++ b/src/components/modal/modalFooter/modalFooter.tsx
@@ -1,6 +1,8 @@
 import { ReactNode, FC, MouseEventHandler } from 'react';
 import classNames from 'classnames/bind';
 import { Button, ButtonProps } from '@components/button';
+import { Tooltip } from '@components/tooltip';
+import { ExtendedButtonProps } from '../types';
 import styles from './modalFooter.module.scss';
 
 const cx = classNames.bind(styles);
@@ -10,7 +12,7 @@ export type ModalSize = 'default' | 'small' | 'large';
 interface ModalFooterProps {
   closeHandler: MouseEventHandler<HTMLButtonElement>;
   footerNode?: ReactNode;
-  okButton?: ButtonProps;
+  okButton?: ExtendedButtonProps;
   cancelButton?: ButtonProps;
   size?: ModalSize;
 }
@@ -22,6 +24,21 @@ export const ModalFooter: FC<ModalFooterProps> = ({
   cancelButton,
   size,
 }) => {
+  const { tooltipNode, ...okButtonProps } = okButton || {};
+
+  const renderOkButton = () => {
+    const button = (
+      <Button adjustWidthOn={size === 'small' ? 'parent' : 'min-width'} {...okButtonProps} />
+    );
+    return tooltipNode ? (
+      <Tooltip content={tooltipNode} placement="top" width={270}>
+        {button}
+      </Tooltip>
+    ) : (
+      button
+    );
+  };
+
   return (
     <div className={cx('modal-footer', { 'with-extra-node': footerNode, [`size-${size}`]: size })}>
       {footerNode && footerNode}
@@ -36,11 +53,7 @@ export const ModalFooter: FC<ModalFooterProps> = ({
             />
           </div>
         )}
-        {okButton && (
-          <div className={cx('button-container')}>
-            <Button adjustWidthOn={size === 'small' ? 'parent' : 'min-width'} {...okButton} />
-          </div>
-        )}
+        {okButton && <div className={cx('button-container')}>{renderOkButton()}</div>}
       </div>
     </div>
   );

--- a/src/components/modal/types.ts
+++ b/src/components/modal/types.ts
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import { ButtonProps } from '../button';
+
+export interface ExtendedButtonProps extends ButtonProps {
+  tooltipNode?: ReactNode;
+}


### PR DESCRIPTION
## Changes
1. Added ability to show tooltip on OK button

## Visuals
<img width="773" height="706" alt="image" src="https://github.com/user-attachments/assets/2aec377a-c57b-4bb8-a800-10556b1288ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Modal now supports an optional tooltip on the OK button. When provided, the tooltip appears on hover/focus without affecting layout or cancel button behavior.
  - Configure via the OK button’s props to display helpful guidance or warnings.

- Documentation
  - Updated Modal documentation to highlight tooltip support on the OK button and clarify usage.
  - Added a new Storybook example demonstrating a Modal with a tooltip-enabled OK button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->