### PR TITLE
Allow providing custom error messages to file drop zone files

### DIFF
--- a/src/components/attachedFile/attachedFile.module.scss
+++ b/src/components/attachedFile/attachedFile.module.scss
@@ -191,5 +191,15 @@
         fill: var(--rp-ui-base-topaz-hover);
       }
     }
+
+    &--disabled {
+      cursor: default;
+
+      &:hover {
+        svg path {
+          fill: var(--rp-ui-base-e-300);
+        }
+      }
+    }
   }
 }

--- a/src/components/attachedFile/attachedFile.tsx
+++ b/src/components/attachedFile/attachedFile.tsx
@@ -82,9 +82,11 @@ export const AttachedFile = ({
   const handleRemove = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
-      onRemove?.();
+      if (!isUploading) {
+        onRemove?.();
+      }
     },
-    [onRemove],
+    [isUploading, onRemove],
   );
 
   const downloadFile = useCallback(
@@ -136,7 +138,14 @@ export const AttachedFile = ({
         )}
       </div>
       {onRemove && (
-        <button type="button" className={cx('attached-file__remove-button')} onClick={handleRemove}>
+        <button
+          type="button"
+          className={cx('attached-file__remove-button', {
+            'attached-file__remove-button--disabled': isUploading,
+          })}
+          disabled={isUploading}
+          onClick={handleRemove}
+        >
           <CloseIcon />
         </button>
       )}

--- a/src/components/fileDropArea/attachedFilesList/attachedFilesList.module.scss
+++ b/src/components/fileDropArea/attachedFilesList/attachedFilesList.module.scss
@@ -20,6 +20,7 @@
   gap: 8px;
   max-width: 100%;
   margin-top: 16px;
+  padding-bottom: 3px;
 
   &:has(> *:only-child) {
     grid-template-columns: 1fr;

--- a/src/components/fileDropArea/attachedFilesList/attachedFilesList.tsx
+++ b/src/components/fileDropArea/attachedFilesList/attachedFilesList.tsx
@@ -37,6 +37,7 @@ export interface AttachmentFile {
   isUploadFailed?: boolean;
   isUploading?: boolean;
   validationErrors?: FileValidationError[];
+  customErrorMessage?: string;
 }
 
 interface AttachedFilesListProps {
@@ -82,6 +83,7 @@ export const AttachedFilesList = ({
         const validationErrorMessage = getValidationErrorMessage(
           file.validationErrors ?? [],
           messages,
+          file.customErrorMessage,
         );
 
         return (

--- a/src/components/fileDropArea/fileDropArea.module.scss
+++ b/src/components/fileDropArea/fileDropArea.module.scss
@@ -26,6 +26,7 @@
   border-radius: 8px;
   background-color: var(--rp-ui-base-bg-200);
   cursor: pointer;
+  box-sizing: border-box;
 
   &--active,
   &:hover {

--- a/src/components/fileDropArea/fileDropArea.stories.tsx
+++ b/src/components/fileDropArea/fileDropArea.stories.tsx
@@ -112,6 +112,7 @@ export const WithFileList = () => {
       size: Math.round((fileWithValidation.file.size / (1024 * 1024)) * 100) / 100,
       isUploading: false,
       validationErrors: fileWithValidation.validationErrors,
+      customErrorMessage: fileWithValidation.customErrorMessage,
     }));
     setAttachedFiles((prev) => [...prev, ...newFiles]);
   };
@@ -159,6 +160,7 @@ export const OverlayVariant = () => {
       size: Math.round((fileWithValidation.file.size / (1024 * 1024)) * 100) / 100,
       isUploading: false,
       validationErrors: fileWithValidation.validationErrors,
+      customErrorMessage: fileWithValidation.customErrorMessage,
     }));
 
     setAttachedFiles((prev) => [...prev, ...newFiles]);

--- a/src/components/fileDropArea/hooks/useFileProcessing.ts
+++ b/src/components/fileDropArea/hooks/useFileProcessing.ts
@@ -83,9 +83,9 @@ export const useFileProcessing = ({
   }, []);
 
   return {
-    onDrop,
-    handleFileInputChange,
     error,
+    handleFileInputChange,
     clearError,
+    onDrop,
   };
 };

--- a/src/components/fileDropArea/types.ts
+++ b/src/components/fileDropArea/types.ts
@@ -70,6 +70,7 @@ export interface FileValidationOptions {
 export interface FileWithValidation {
   file: File;
   validationErrors: FileValidationError[];
+  customErrorMessage?: string;
 }
 
 export interface FileDropAreaBaseConfig extends FileValidationOptions {

--- a/src/components/fileDropArea/utils/getValidationErrorMessage.ts
+++ b/src/components/fileDropArea/utils/getValidationErrorMessage.ts
@@ -21,7 +21,12 @@ import { FileValidationError, FileValidationMessages } from '../types';
 export const getValidationErrorMessage = (
   errors: FileValidationError[],
   messages: FileValidationMessages,
+  customErrorMessage?: string,
 ) => {
+  if (customErrorMessage) {
+    return customErrorMessage;
+  }
+
   if (isEmpty(errors)) {
     return null;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - File attachments can display custom error messages to clarify upload issues.
  - Upload status reflects failures when a custom error message is present.
  - Users can clear displayed file errors during file processing.

- Style
  - Improved spacing in the attached files list for better readability.
  - Ensured consistent sizing of the file drop area with box-sizing adjustments.
  - Remove button shows a disabled state while uploads are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->