### PR TITLE
add coveredManually icon and new purple color

### DIFF
--- a/src/assets/styles/themes/base.scss
+++ b/src/assets/styles/themes/base.scss
@@ -68,6 +68,7 @@
   --rp-ui-base-sm-info-line-100: #ced3db;
 
   --rp-ui-base-defect-type-AB: #ffc208;
+  --rp-ui-base-purple-600: #8866aa;
 
   --rp-ui-base-tag-value-text: #394db6;
   --rp-ui-base-tag-value-background: #ced8fc;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -14,6 +14,7 @@ export { default as ClearIcon } from './svg/clear.svg';
 export { default as CloseEyeIcon } from './svg/closeEye.svg';
 export { default as CloseIcon } from './svg/close.svg';
 export { default as CopyIcon } from './svg/copy.svg';
+export { default as CoveredManuallyIcon } from './svg/coveredManually.svg';
 export { default as CsvIcon } from './svg/csv.svg';
 export { default as DeleteIcon } from './svg/delete.svg';
 export { default as DragAndDropIcon } from './svg/dragAndDrop.svg';

--- a/src/components/icons/svg/coveredManually.svg
+++ b/src/components/icons/svg/coveredManually.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13 2H3C2.44772 2 2 2.44772 2 3V13C2 13.5523 2.44772 14 3 14H13C13.5523 14 14 13.5523 14 13V3C14 2.44772 13.5523 2 13 2ZM3 1C1.89543 1 1 1.89543 1 3V13C1 14.1046 1.89543 15 3 15H13C14.1046 15 15 14.1046 15 13V3C15 1.89543 14.1046 1 13 1H3Z" fill="#A2AAB5"/>
+<rect x="8" y="3" width="7.07214" height="7.07214" transform="rotate(45 8 3)" fill="#A2AAB5"/>
+</svg>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new theme color token (purple 600) to expand the design palette for UI elements.
  - Added a “Covered Manually” icon, now available for use across the interface.
  - These additions enhance visual customization and iconography without altering existing behavior or styles.
  - No breaking changes; existing colors and icons remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->