### PR TITLE
Allow providing min height to `FieldTextFlex`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,18 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/components/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/components/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./fileDropArea": {
+      "types": "./dist/components/fileDropArea/index.d.ts",
+      "import": "./dist/fileDropArea.js",
+      "default": "./dist/fileDropArea.js"
+    }
+  },
   "peerDependencies": {
     "react": "17.x-18.x",
     "react-dom": "17.x-18.x"

--- a/src/components/fieldTextFlex/fieldTextFlex.module.scss
+++ b/src/components/fieldTextFlex/fieldTextFlex.module.scss
@@ -11,7 +11,6 @@
 .text-area {
   @include font-scale();
   width: 100%;
-  min-height: 72px;
   padding: 7px 12px;
   outline: none;
   border: 1px solid var(--rp-ui-color-field-border-3);

--- a/src/components/fieldTextFlex/fieldTextFlex.stories.tsx
+++ b/src/components/fieldTextFlex/fieldTextFlex.stories.tsx
@@ -61,6 +61,10 @@ export const WithMaxLengthDisplay: Story = {
   args: { maxLengthDisplay: 60 },
 };
 
+export const WithCustomMinHeight: Story = {
+  args: { minHeight: 36 },
+};
+
 export const FullyDescribed: Story = {
   args: {
     label: 'Label',

--- a/src/components/fieldTextFlex/fieldTextFlex.tsx
+++ b/src/components/fieldTextFlex/fieldTextFlex.tsx
@@ -25,6 +25,7 @@ export interface FieldTextFlexProps extends ComponentPropsWithRef<'textarea'> {
   label?: string;
   helpText?: string;
   maxLengthDisplay?: number;
+  minHeight?: number;
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
   onFocus?: FocusEventHandler<HTMLTextAreaElement>;
   onBlur?: FocusEventHandler<HTMLTextAreaElement>;
@@ -47,6 +48,7 @@ export const FieldTextFlex = forwardRef(
       className = '',
       label = '',
       helpText = '',
+      minHeight = HEIGHT,
       maxLengthDisplay,
       onChange,
       onFocus,
@@ -60,7 +62,7 @@ export const FieldTextFlex = forwardRef(
     const hasError = error && touched;
 
     const resizeHeight = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      event.target.style.height = `${HEIGHT}px`;
+      event.target.style.height = `${minHeight}px`;
       event.target.style.height = `${event.target.scrollHeight + BORDER}px`;
     };
 
@@ -79,6 +81,7 @@ export const FieldTextFlex = forwardRef(
             error,
             touched,
           })}
+          style={{ minHeight, height: minHeight }}
           value={value}
           placeholder={placeholder}
           disabled={disabled}

--- a/src/components/fileDropArea/index.ts
+++ b/src/components/fileDropArea/index.ts
@@ -15,9 +15,14 @@
  */
 
 import { FileDropArea } from './fileDropArea';
-import { MIME_TYPES } from './types';
-import type { FileWithValidation } from './types';
+import {
+  MIME_TYPES,
+  FileValidationError,
+  type MimeType,
+  type FileWithValidation,
+  type FileValidationMessages,
+} from './types';
 
 export { FileDropArea };
-export { MIME_TYPES };
-export type { FileWithValidation };
+export { MIME_TYPES, FileValidationError };
+export type { MimeType, FileWithValidation, FileValidationMessages };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,7 +10,7 @@ export { FieldLabel } from './fieldLabel';
 export { FieldNumber } from './fieldNumber';
 export { FieldText } from './fieldText';
 export { FieldTextFlex } from './fieldTextFlex';
-export { FileDropArea, MIME_TYPES } from './fileDropArea';
+export { FileDropArea } from './fileDropArea';
 export { Modal } from './modal';
 export { MultipleAutocomplete } from './autocompletes/multipleAutocomplete';
 export { Pagination } from './pagination';


### PR DESCRIPTION

https://github.com/user-attachments/assets/5d6a72fa-4245-452a-be6b-9e98aa035e2f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text field components accept a configurable minimum height; a story demonstrates a custom minHeight.

* **Style**
  * Removed the default fixed min-height from text areas for a more compact default layout while preserving custom heights.

* **Chores**
  * File-drop exports expanded; one previously re-exported constant was removed from the main components barrel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->