### PR TITLE
[BREAKING] Update package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,15 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
-    "./fileDropArea": {
-      "types": "./dist/components/fileDropArea/index.d.ts",
-      "import": "./dist/fileDropArea.js",
-      "default": "./dist/fileDropArea.js"
+    "./style.css": "./dist/style.css",
+    "./common": {
+      "types": "./dist/common/types.d.ts",
+      "default": "./dist/common/types.d.ts"
+    },
+    "./*": {
+      "types": "./dist/components/*/index.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
     }
   },
   "peerDependencies": {

--- a/src/components/modal/index.ts
+++ b/src/components/modal/index.ts
@@ -2,3 +2,4 @@ export { Modal } from './modal';
 export { ModalContent } from './modalContent';
 export { ModalHeader } from './modalHeader';
 export { ModalFooter } from './modalFooter';
+export type { ExtendedButtonProps } from './types';

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -1,5 +1,18 @@
 import { Table } from './table';
 
 export { Table };
+export type {
+  RowData,
+  Column,
+  PrimaryColumn,
+  FixedColumn,
+  PinnedColumn,
+  RowConfigs,
+  DetailedCellData,
+  MetaData,
+  SortConfig,
+  SortingDirection,
+  TableComponentProps,
+} from './types';
 
 export default Table;


### PR DESCRIPTION
### Breaking changes
- `@reportportal/ui-kit/common/types` removed → use `@reportportal/ui-kit/common`.
- Deep imports into `dist` no longer supported.

### Migration
- Types:
  - From: `import type { X } from '@reportportal/ui-kit/common/types'`
  - To: `import type { X } from '@reportportal/ui-kit/common'`
- Components (example: Popover):
  - From: `import { Popover } from '@reportportal/ui-kit/dist/components/popover'`
  - To: `import { Popover } from '@reportportal/ui-kit/popover'`
- General rule:
  - From: `@reportportal/ui-kit/dist/components/{component}`
  - To: `@reportportal/ui-kit/{component}`

### New import patterns
```ts
// Root exports
import { Button, Modal } from '@reportportal/ui-kit';

// Subpath per component
import { ButtonProps } from '@reportportal/ui-kit/button';
import { ModalContent } from '@reportportal/ui-kit/modal';

// Shared types
import type { SomeSharedType } from '@reportportal/ui-kit/common';

// Styles
import '@reportportal/ui-kit/style.css';
```

### Notes
- Requires TypeScript ≥ 4.7 (consumers on 5.8.x are OK).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized package exports structure for improved accessibility.
  * Made CSS styles available as a standalone import.
  * Enhanced type definitions export for improved TypeScript support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->