### PR TITLE
EPMRPP-109246 || Add configurable column width and optional header tooltip support

### DIFF
--- a/src/components/table/table.module.scss
+++ b/src/components/table/table.module.scss
@@ -312,6 +312,14 @@ $PADDING_VERTICAL-LARGE: 30px;
   .label {
     display: flex;
     align-items: center;
+    min-width: 0;
+
+    > span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
   }
 
   &.sortable-cell > .label {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -195,7 +195,7 @@ export const Table: FC<TableComponentProps> = ({
               onMouseEnter={() => handleColumnMouseEnter(column.key)}
               onMouseLeave={handleColumnMouseLeave}
             >
-              <span>{column.header}</span>
+              <span title={column.showTooltip ? column.header : undefined}>{column.header}</span>
               {(hoveredColumn === column.key || defaultSortingColumn?.key === column.key) &&
                 getSortIcon(column.key)}
             </div>
@@ -225,7 +225,7 @@ export const Table: FC<TableComponentProps> = ({
               onMouseEnter={() => handleColumnMouseEnter(column.key)}
               onMouseLeave={handleColumnMouseLeave}
             >
-              <span>{column.header}</span>
+              <span title={column.showTooltip ? column.header : undefined}>{column.header}</span>
               {(hoveredColumn === column.key || defaultSortingColumn?.key === column.key) &&
                 getSortIcon(column.key)}
             </div>

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,8 +1,8 @@
-import { useMemo, FC } from 'react';
+import { useMemo, FC, useEffect, useRef, useState } from 'react';
 import styles from './table.module.scss';
 import classNames from 'classnames/bind';
 import { ArrowDownIcon, ArrowUpIcon, ChevronDownDropdownIcon } from '@components/icons';
-import { TableComponentProps, FixedColumn, Column } from './types';
+import { TableComponentProps, FixedColumn, Column, PrimaryColumn } from './types';
 import { Checkbox } from '@components/checkbox';
 import {
   getColumnsKeys,
@@ -16,6 +16,25 @@ import { ASC, EXPANDABLE_CHECKBOX_COLUMN_WIDTH } from './constants';
 import { useTableColumns, useTableHover, useTableExpansion, useColumnWidths } from './hooks';
 
 const cx = classNames.bind(styles);
+
+const ColumnHeaderText: FC<{ column: PrimaryColumn | FixedColumn }> = ({ column }) => {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const [showTitle, setShowTitle] = useState(false);
+
+  useEffect(() => {
+    if (spanRef.current) {
+      const width = spanRef.current.offsetWidth;
+      const scrollWidth = spanRef.current.scrollWidth;
+      setShowTitle(scrollWidth > width);
+    }
+  }, [column.header]);
+
+  return (
+    <span ref={spanRef} title={showTitle ? column.header : undefined}>
+      {column.header}
+    </span>
+  );
+};
 
 export const Table: FC<TableComponentProps> = ({
   data,
@@ -195,7 +214,7 @@ export const Table: FC<TableComponentProps> = ({
               onMouseEnter={() => handleColumnMouseEnter(column.key)}
               onMouseLeave={handleColumnMouseLeave}
             >
-              <span title={column.showTooltip ? column.header : undefined}>{column.header}</span>
+              <ColumnHeaderText column={column} />
               {(hoveredColumn === column.key || defaultSortingColumn?.key === column.key) &&
                 getSortIcon(column.key)}
             </div>
@@ -225,7 +244,7 @@ export const Table: FC<TableComponentProps> = ({
               onMouseEnter={() => handleColumnMouseEnter(column.key)}
               onMouseLeave={handleColumnMouseLeave}
             >
-              <span title={column.showTooltip ? column.header : undefined}>{column.header}</span>
+              <ColumnHeaderText column={column} />
               {(hoveredColumn === column.key || defaultSortingColumn?.key === column.key) &&
                 getSortIcon(column.key)}
             </div>

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -4,9 +4,11 @@ import { ASC, DESC } from './constants';
 export interface Column {
   key: string;
   header: string;
+  showTooltip?: boolean;
 }
 export interface PrimaryColumn extends Column {
   primary: boolean;
+  width?: string | number;
 }
 export interface FixedColumn extends Column {
   width: string | number;

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -4,7 +4,6 @@ import { ASC, DESC } from './constants';
 export interface Column {
   key: string;
   header: string;
-  showTooltip?: boolean;
 }
 export interface PrimaryColumn extends Column {
   primary: boolean;

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -130,7 +130,13 @@ export const getGridTemplateColumns = (
 
   const addColumnWidth = (column: PrimaryColumn | FixedColumn) => {
     if (isPrimaryColumn(column)) {
-      columns.push(`minmax(${PRIMARY_COLUMN_DEFAULT_WIDTH}px, 1fr)`);
+      const primaryColumn = column as PrimaryColumn;
+      const minWidth = primaryColumn.width
+        ? isString(primaryColumn.width)
+          ? primaryColumn.width
+          : `${primaryColumn.width}px`
+        : `${PRIMARY_COLUMN_DEFAULT_WIDTH}px`;
+      columns.push(`minmax(${minWidth}, 1fr)`);
     } else {
       const fixedColumn = column as FixedColumn;
       const width = isString(fixedColumn.width) ? fixedColumn.width : `${fixedColumn.width}px`;


### PR DESCRIPTION
## Table Component Enhancements

### Summary
This PR adds two improvements to the Table component:
1. Optional `width` parameter for primary columns
2. Text ellipsis with optional native tooltip for narrow column headers

### Changes

#### 1. Primary Column Width Support

**Problem:** Primary columns (pinned columns) always used a hardcoded minimum width of 100px (`minmax(100px, 1fr)`), regardless of configuration.

**Solution:** Added optional `width` parameter to `PrimaryColumn` interface that allows customizing the minimum width:

- **types.ts**: Added `width?: string | number` to `PrimaryColumn` interface
- **utils.ts**: Updated `addColumnWidth` function to use column-specific width if provided, otherwise fall back to `PRIMARY_COLUMN_DEFAULT_WIDTH`

**Usage:**
```typescript
primaryColumn: {
  key: 'name',
  header: 'Name',
  width: 300  // Sets minmax(300px, 1fr) instead of default minmax(100px, 1fr)
}
```

**Backward compatibility:** Fully maintained - if `width` is not specified, defaults to 100px as before.

---

#### 2. Text Ellipsis for Narrow Column Headers

**Problem:** When column header text was wider than the column width, it was cut off without ellipsis, making it hard to read truncated headers.

**Solution:** Implemented two-part fix:

- **table.module.scss**: Added CSS rules to `.label > span` for proper text truncation:
  - `overflow: hidden`
  - `text-overflow: ellipsis`
  - `white-space: nowrap`
  - `min-width: 0` (allows flex child to shrink below content size)

- ~~**types.ts**: Added `showTooltip?: boolean` to `Column` interface~~
- **table.tsx**: Conditionally render `title` attribute on header `<span>` ~~when `showTooltip: true`~~

**Backward compatibility:**   tooltip is only shown when needed ~~`showTooltip: true` is explicitly set.~~

### UPDATE
### Auto-Tooltip for Truncated Headers

Column headers now show a tooltip with full text when truncated. The component automatically detects text overflow and displays native browser tooltip only when needed. No API changes required - works automatically for all existing tables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional hover tooltips for table headers to reveal full header text.
  * Primary columns can now have configurable widths for more flexible table layouts.

* **Bug Fixes**
  * Long header text is now truncated with ellipsis to prevent overflow and preserve layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->