### PR TITLE
fix: add dropdown mode for autocomplete

### DIFF
--- a/src/components/autocompletes/common/autocompleteMenu/autocompleteMenu.tsx
+++ b/src/components/autocompletes/common/autocompleteMenu/autocompleteMenu.tsx
@@ -48,11 +48,6 @@ export const AutocompleteMenu = forwardRef(
     }: AutocompleteMenuProps<T>,
     ref: ForwardedRef<HTMLUListElement>,
   ) => {
-    console.log({
-      isDropdownMode,
-      isOpen,
-      opened: isOpen && (isDropdownMode || isReadyForSearch(minLength, inputValue)),
-    });
     return (
       <ul
         ref={ref}

--- a/src/components/autocompletes/common/autocompleteMenu/autocompleteMenu.tsx
+++ b/src/components/autocompletes/common/autocompleteMenu/autocompleteMenu.tsx
@@ -29,7 +29,8 @@ const isReadyForSearch = (minLength: number | null, inputValue: string) =>
 type AutocompleteMenuProps<T> = {
   isOpen?: boolean;
   style?: React.CSSProperties;
-  minLength: number | null;
+  isDropdownMode?: boolean;
+  minLength?: number | null;
   inputValue?: string;
   className?: string;
 } & AutocompleteOptionsProps<T>;
@@ -40,18 +41,24 @@ export const AutocompleteMenu = forwardRef(
       isOpen = false,
       style = {},
       minLength = 1,
+      isDropdownMode,
       inputValue = '',
       className = '',
       ...props
     }: AutocompleteMenuProps<T>,
     ref: ForwardedRef<HTMLUListElement>,
   ) => {
+    console.log({
+      isDropdownMode,
+      isOpen,
+      opened: isOpen && (isDropdownMode || isReadyForSearch(minLength, inputValue)),
+    });
     return (
       <ul
         ref={ref}
         className={cx(
           'menu',
-          { opened: isOpen && isReadyForSearch(minLength, inputValue) },
+          { opened: isOpen && (isDropdownMode || isReadyForSearch(minLength, inputValue)) },
           className,
         )}
         style={style}

--- a/src/components/autocompletes/common/autocompleteOptions.tsx
+++ b/src/components/autocompletes/common/autocompleteOptions.tsx
@@ -31,7 +31,7 @@ const cx = classNames.bind(styles);
 
 export interface AutocompleteOptionsProps<T> {
   options: T[];
-  loading: boolean;
+  loading?: boolean;
   inputValue: string;
   parseValueToString: (value: T | null) => string;
   getItemProps: GetItemPropsT<T>;
@@ -41,7 +41,7 @@ export interface AutocompleteOptionsProps<T> {
     isNew: boolean,
     getItemProps: GetItemPropsT<T>,
   ) => ReactNode;
-  async: boolean;
+  async?: boolean;
   optionVariant: 'key-variant' | 'value-variant' | '';
   createWithoutConfirmation: boolean;
   customEmptyListMessage?: string;

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.module.scss
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.module.scss
@@ -57,7 +57,7 @@ $SCREEN_XS_MAX: 767px;
 .autocomplete {
   &-wrapper {
     position: relative;
-    width: max-content;
+    width: 100%;
   }
 
   @include container(var(--rp-ui-color-field-border), var(--rp-ui-color-bg));

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.module.scss
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.module.scss
@@ -152,3 +152,17 @@ $SCREEN_XS_MAX: 767px;
   line-height: 16px;
   color: var(--rp-ui-color-error);
 }
+
+.dropdown-button {
+  outline: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.icon-reversed {
+  svg {
+    transform: rotateZ(180deg);
+  }
+}

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.stories.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.stories.tsx
@@ -63,7 +63,7 @@ const TEST_DATA_STRINGS: Partial<
   >
 > = {
   options: OPTIONS_STRINGS,
-  loading: true,
+  loading: false,
   async: true,
   createWithoutConfirmation: true,
   creatable: false,
@@ -82,6 +82,7 @@ const TEST_DATA_STRINGS: Partial<
     clearable: true,
   },
   minLength: 1,
+  isDropdownMode: true,
   placeholder: 'Test placeholder',
   disabled: false,
   mobileDisabled: false,

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -101,7 +101,7 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
     onFocus = () => {},
     onBlur = () => {},
     disabled = false,
-    isDropdownMode,
+    isDropdownMode = false,
     mobileDisabled = false,
     inputProps = {},
     parseValueToString = ((item: T) =>

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -18,7 +18,7 @@ import { ComponentProps, KeyboardEvent, ReactNode, useEffect, useRef } from 'rea
 import classNames from 'classnames/bind';
 import { ControllerStateAndHelpers } from 'downshift';
 
-import { ClearIcon } from '@/components/icons';
+import { ArrowDownIcon, ArrowUpIcon, ClearIcon } from '@/components/icons';
 import { default as FieldText } from '@/components/fieldText';
 import { useFloating, autoUpdate } from '@floating-ui/react';
 
@@ -67,6 +67,7 @@ export interface MultipleAutocompleteProps<T> {
   createWithoutConfirmation: boolean;
   getItemValidationErrorType?: (item: T) => string;
   clearItemsError: () => void;
+  isDropdownMode?: boolean;
   getAdditionalCreationCondition: (value: string) => boolean;
   highlightUnStoredItem: boolean;
   parseInputValueFn: ((value: string) => T[]) | null;
@@ -100,6 +101,7 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
     onFocus = () => {},
     onBlur = () => {},
     disabled = false,
+    isDropdownMode,
     mobileDisabled = false,
     inputProps = {},
     parseValueToString = ((item: T) =>
@@ -229,6 +231,7 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
           openMenu,
           selectItem,
           clearSelection,
+          toggleMenu,
           storedItemsMap,
           getRootProps,
         }: GetStateAndHelpersT<T>) => (
@@ -318,6 +321,11 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
                     <ClearIcon />
                   </button>
                 )}
+                {isDropdownMode && (
+                  <button onClick={() => toggleMenu()}>
+                    {isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
+                  </button>
+                )}
               </div>
               {error && touched && <span className={cx('error-text')}>{error}</span>}
             </>
@@ -327,6 +335,7 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
               async={async}
               ref={refs.setFloating}
               newItemButtonText={newItemButtonText}
+              isDropdownMode={isDropdownMode}
               style={floatingStyles}
               inputValue={(inputValue || '').trim()}
               getItemProps={getOptionProps(getItemProps, highlightedIndex, value)}

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -60,9 +60,9 @@ export interface MultipleAutocompleteProps<T> {
   mobileDisabled: boolean;
   inputProps: ComponentProps<typeof FieldText>;
   parseValueToString: (value: T | null) => string;
-  minLength: number | null;
-  maxLength: number | null;
-  async: boolean;
+  minLength?: number | null;
+  maxLength?: number | null;
+  async?: boolean;
   customClass: string;
   createWithoutConfirmation: boolean;
   getItemValidationErrorType?: (item: T) => string;
@@ -73,7 +73,7 @@ export interface MultipleAutocompleteProps<T> {
   handleUnStoredItemCb:
     | ((newSelectedItems: DownshiftStore<T>, prevSelectedItems: DownshiftStore<T>) => void)
     | null;
-  dataAutomationId: string;
+  dataAutomationId?: string;
   existingItemsMap: Record<string | number, boolean>;
   optionVariant: ComponentProps<typeof AutocompleteMenu>['optionVariant'];
   customizeNewSelectedValue: (value: T) => T;

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -18,7 +18,7 @@ import { ComponentProps, KeyboardEvent, ReactNode, useEffect, useRef } from 'rea
 import classNames from 'classnames/bind';
 import { ControllerStateAndHelpers } from 'downshift';
 
-import { ArrowDownIcon, ArrowUpIcon, ClearIcon } from '@/components/icons';
+import { ClearIcon, DropdownIcon } from '@/components/icons';
 import { default as FieldText } from '@/components/fieldText';
 import { useFloating, autoUpdate } from '@floating-ui/react';
 
@@ -322,8 +322,14 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
                   </button>
                 )}
                 {isDropdownMode && (
-                  <button onClick={() => toggleMenu()}>
-                    {isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
+                  <button
+                    type="button"
+                    className={cx('dropdown-button', { ['icon-reversed']: isOpen })}
+                    onClick={() => toggleMenu()}
+                    aria-label="Toggle dropdown"
+                    aria-expanded={isOpen}
+                  >
+                    <DropdownIcon />
                   </button>
                 )}
               </div>

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.module.scss
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.module.scss
@@ -2,3 +2,11 @@
   position: relative;
   width: max-content;
 }
+
+.dropdown-button {
+  outline: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  border: none;
+}

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.module.scss
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.module.scss
@@ -1,6 +1,6 @@
 .input-wrapper {
   position: relative;
-  width: max-content;
+  width: 100%;
 }
 
 .dropdown-button {

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.module.scss
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.module.scss
@@ -10,3 +10,9 @@
   padding: 0;
   border: none;
 }
+
+.icon-reversed {
+  svg {
+    transform: rotateZ(180deg);
+  }
+}

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.stories.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.stories.tsx
@@ -27,7 +27,7 @@ const TEST_DATA_OBJECTS: Partial<
   >
 > = {
   options: OPTIONS_OBJECTS,
-  loading: true,
+  loading: false,
   async: true,
   createWithoutConfirmation: true,
   parseValueToString: (value) => {
@@ -38,6 +38,7 @@ const TEST_DATA_OBJECTS: Partial<
   touched: true,
   minLength: 1,
   placeholder: 'Test placeholder',
+  isDropdownMode: true,
   disabled: false,
   inputProps: {
     clearable: true,

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -20,13 +20,13 @@ import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
 import { autoUpdate, useFloating } from '@floating-ui/react';
 
 import { default as FieldText } from '@/components/fieldText';
+import { DropdownIcon } from '@/components/icons';
 
 import { AutocompleteMenu } from '../common/autocompleteMenu';
 import { ENTER_KEY_NAME, TAB_KEY_NAME } from '../constants';
 import { GetItemPropsT } from '../types';
 
 import styles from './singleAutocomplete.module.scss';
-import { ArrowDownIcon, ArrowUpIcon } from '@/components/icons';
 
 const cx = classNames.bind(styles);
 
@@ -211,12 +211,12 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
                 additionalIcon: isDropdownMode ? (
                   <button
                     type="button"
-                    className={cx('dropdown-button')}
+                    className={cx('dropdown-button', { ['icon-reversed']: isOpen })}
                     onClick={() => toggleMenu()}
                     aria-label="Toggle dropdown"
                     aria-expanded={isOpen}
                   >
-                    {isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
+                    <DropdownIcon />
                   </button>
                 ) : null,
                 minLength: isDropdownMode ? 0 : minLength,

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -206,15 +206,13 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
                 isRequired,
                 touched,
                 error,
-
                 ...inputProps,
-                endIcon: isDropdownMode ? (
+                endIcon: icon,
+                additionalIcon: isDropdownMode ? (
                   <button className={cx('dropdown-button')} onClick={() => toggleMenu()}>
                     {isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
                   </button>
-                ) : (
-                  icon
-                ),
+                ) : null,
                 minLength: isDropdownMode ? 0 : minLength,
               })}
             />

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -26,6 +26,7 @@ import { ENTER_KEY_NAME, TAB_KEY_NAME } from '../constants';
 import { GetItemPropsT } from '../types';
 
 import styles from './singleAutocomplete.module.scss';
+import { ArrowDownIcon, ArrowUpIcon } from '@/components/icons';
 
 const cx = classNames.bind(styles);
 
@@ -33,15 +34,15 @@ const DEFAULT_OPTIONS_INDEX = 0;
 
 export interface SingleAutocompleteProps<T> {
   options: T[];
-  loading: boolean;
+  loading?: boolean;
   onStateChange: ComponentProps<typeof Downshift<T>>['onStateChange'];
   value: T | null;
   placeholder: string;
   onChange: ComponentProps<typeof Downshift<T>>['onChange'];
   onFocus: () => void;
   onBlur: (e: FocusEvent<HTMLInputElement>) => void;
-  disabled: boolean;
-  inputProps: ComponentProps<typeof FieldText>;
+  disabled?: boolean;
+  inputProps?: ComponentProps<typeof FieldText>;
   parseValueToString: (value: T | null) => string;
   renderOption?: (
     value: T,
@@ -49,17 +50,18 @@ export interface SingleAutocompleteProps<T> {
     isNew: boolean,
     getItemProps: GetItemPropsT<T>,
   ) => ReactNode;
-  minLength: number;
-  maxLength: number | null;
-  async: boolean;
+  minLength?: number;
+  maxLength?: number | null;
+  async?: boolean;
   optionVariant: ComponentProps<typeof AutocompleteMenu>['optionVariant'];
-  isRequired: boolean;
+  isRequired?: boolean;
   error: string;
-  touched: boolean;
+  touched?: boolean;
   setTouch?: (value: boolean) => void;
   createWithoutConfirmation: boolean;
-  menuClassName: string;
+  menuClassName?: string;
   icon?: ReactNode;
+  isDropdownMode?: boolean;
   skipOptionCreation?: boolean;
   isOptionUnique?: (value: boolean | null) => void;
   refFunction?: Ref<HTMLInputElement>;
@@ -96,6 +98,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
     createWithoutConfirmation = false,
     menuClassName = '',
     icon,
+    isDropdownMode = true,
     isOptionUnique,
     refFunction,
     stateReducer,
@@ -149,6 +152,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
         getInputProps,
         getItemProps,
         setHighlightedIndex,
+        toggleMenu,
         isOpen,
         inputValue,
         highlightedIndex,
@@ -202,12 +206,21 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
                 isRequired,
                 touched,
                 error,
-                endIcon: icon,
+
                 ...inputProps,
+                endIcon: isDropdownMode ? (
+                  <button className={cx('dropdown-button')} onClick={() => toggleMenu()}>
+                    {isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
+                  </button>
+                ) : (
+                  icon
+                ),
+                minLength: isDropdownMode ? 0 : minLength,
               })}
             />
             <AutocompleteMenu
               isOpen={isOpen}
+              isDropdownMode={isDropdownMode}
               style={floatingStyles}
               ref={refs.setFloating}
               minLength={minLength}

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -209,7 +209,13 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
                 ...inputProps,
                 endIcon: icon,
                 additionalIcon: isDropdownMode ? (
-                  <button className={cx('dropdown-button')} onClick={() => toggleMenu()}>
+                  <button
+                    type="button"
+                    className={cx('dropdown-button')}
+                    onClick={() => toggleMenu()}
+                    aria-label="Toggle dropdown"
+                    aria-expanded={isOpen}
+                  >
                     {isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
                   </button>
                 ) : null,

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -207,18 +207,20 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
                 touched,
                 error,
                 ...inputProps,
-                endIcon: icon,
-                additionalIcon: isDropdownMode ? (
-                  <button
-                    type="button"
-                    className={cx('dropdown-button', { ['icon-reversed']: isOpen })}
-                    onClick={() => toggleMenu()}
-                    aria-label="Toggle dropdown"
-                    aria-expanded={isOpen}
-                  >
-                    <DropdownIcon />
-                  </button>
-                ) : null,
+                endIcon:
+                  isDropdownMode && !icon ? (
+                    <button
+                      type="button"
+                      className={cx('dropdown-button', { ['icon-reversed']: isOpen })}
+                      onClick={() => toggleMenu()}
+                      aria-label="Toggle dropdown"
+                      aria-expanded={isOpen}
+                    >
+                      <DropdownIcon />
+                    </button>
+                  ) : (
+                    icon
+                  ),
                 minLength: isDropdownMode ? 0 : minLength,
               })}
             />

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -98,7 +98,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
     createWithoutConfirmation = false,
     menuClassName = '',
     icon,
-    isDropdownMode = true,
+    isDropdownMode = false,
     isOptionUnique,
     refFunction,
     stateReducer,

--- a/src/components/fieldText/fieldText.module.scss
+++ b/src/components/fieldText/fieldText.module.scss
@@ -42,6 +42,11 @@
   margin-left: 4px;
 }
 
+.icon-container-additional {
+  @extend .icon-container;
+  margin-left: 4px;
+}
+
 .field {
   display: flex;
   align-items: center;

--- a/src/components/fieldText/fieldText.tsx
+++ b/src/components/fieldText/fieldText.tsx
@@ -41,7 +41,6 @@ export interface FieldTextProps extends InputHTMLAttributes<HTMLInputElement> {
   defaultWidth?: boolean;
   startIcon?: ReactNode;
   endIcon?: ReactNode;
-  additionalIcon?: ReactNode;
   clearable?: boolean;
   onClear?: (prevValue?: string) => void;
   isRequired?: boolean;
@@ -70,7 +69,6 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
       defaultWidth = true,
       startIcon,
       endIcon,
-      additionalIcon,
       clearable = false,
       onClear,
       isRequired = false,
@@ -205,11 +203,6 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
             value={value.length}
             maxValue={maxLengthDisplay}
           />
-          {endIcon && (
-            <span className={cx('icon-container-end')}>
-              <span className={cx('icon')}>{endIcon}</span>
-            </span>
-          )}
           {clearable && value.length > 0 && (
             <span className={cx('icon-container-end')}>
               <button
@@ -222,9 +215,9 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
               </button>
             </span>
           )}
-          {additionalIcon && (
-            <span className={cx('icon-container-additional')}>
-              <span className={cx('icon')}>{additionalIcon}</span>
+          {endIcon && (
+            <span className={cx('icon-container-end')}>
+              <span className={cx('icon')}>{endIcon}</span>
             </span>
           )}
         </div>

--- a/src/components/fieldText/fieldText.tsx
+++ b/src/components/fieldText/fieldText.tsx
@@ -41,6 +41,7 @@ export interface FieldTextProps extends InputHTMLAttributes<HTMLInputElement> {
   defaultWidth?: boolean;
   startIcon?: ReactNode;
   endIcon?: ReactNode;
+  additionalIcon?: ReactNode;
   clearable?: boolean;
   onClear?: (prevValue?: string) => void;
   isRequired?: boolean;
@@ -69,6 +70,7 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
       defaultWidth = true,
       startIcon,
       endIcon,
+      additionalIcon,
       clearable = false,
       onClear,
       isRequired = false,
@@ -218,6 +220,11 @@ export const FieldText = forwardRef<HTMLInputElement, FieldTextProps>(
               >
                 <ClearIcon />
               </button>
+            </span>
+          )}
+          {additionalIcon && (
+            <span className={cx('icon-container-additional')}>
+              <span className={cx('icon')}>{additionalIcon}</span>
             </span>
           )}
         </div>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdown mode for autocomplete with a toggle button showing open/close icon.

* **Enhancements**
  * Autocomplete and input props relaxed to be optional for more flexible usage.
  * Autocomplete and input wrappers now expand to full width.
  * End-icon rendering reordered in inputs for improved layout.

* **Style**
  * Added spacing class for secondary icons and styles for dropdown button and icon rotation.

* **Tests**
  * Story examples updated to include dropdown mode and adjusted loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



https://github.com/user-attachments/assets/627cf643-98e0-4f79-9912-c0a55c52be99

