### PR TITLE
EPMRPP-109446 || Fixed wrong padding for the cross icon in MultipleAutoComplete component

### DIFF
--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.module.scss
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.module.scss
@@ -78,7 +78,7 @@ $SCREEN_XS_MAX: 767px;
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  padding-left: 14px;
+  padding: 0 0 0 14px;
   outline: none;
   border: none;
   background-color: transparent;


### PR DESCRIPTION
### Description

Cross icon has wrong padding. See the screenshot. Fixed.

### Visuals

**Before:**

<img width="1606" height="847" alt="image" src="https://github.com/user-attachments/assets/05523469-623e-41f1-a37a-da3a83c2aaa3" />

**After:**

<img width="611" height="51" alt="image" src="https://github.com/user-attachments/assets/9c602c38-4af5-44ca-ae06-721a870797f7" />
<img width="617" height="109" alt="image" src="https://github.com/user-attachments/assets/9654ac26-3aca-4a15-8f64-7a27acb0885b" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated internal styling formatting for consistency and maintainability. No user-visible changes.

---

**Note:** This release contains only internal code improvements with no new features or functionality changes for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->