### PR TITLE
EPMRPP-108980 || Add new FiltersButton component

### DIFF
--- a/src/components/filtersButton/filtersButton.module.scss
+++ b/src/components/filtersButton/filtersButton.module.scss
@@ -1,0 +1,116 @@
+.filters-icon-container {
+  all: unset;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  height: 36px;
+  min-width: 40px;
+  border-radius: 20px;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-ui-base-topaz-focused);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  &:not(:disabled):hover {
+    .filter-icon {
+      svg {
+        path {
+          fill: var(--rp-ui-base-e-400);
+        }
+      }
+    }
+  }
+
+  &.opened {
+    .filter-icon {
+      svg {
+        path {
+          fill: var(--rp-ui-base-topaz-pressed);
+        }
+      }
+    }
+
+    &:not(:disabled):hover {
+      .filter-icon {
+        svg {
+          path {
+            fill: var(--rp-ui-base-topaz-hover);
+          }
+        }
+      }
+    }
+  }
+
+  &.with-applied {
+    gap: 8px;
+    padding: 8px 12px;
+    background-color: var(--rp-ui-base-bg-200);
+
+    .filter-icon {
+      svg {
+        path {
+          fill: var(--rp-ui-base-topaz);
+          stroke: var(--rp-ui-base-topaz);
+        }
+      }
+    }
+
+    .filters-count {
+      font-size: 13px;
+      line-height: 20px;
+      color: var(--rp-ui-base-topaz);
+      font-family: var(--rp-ui-base-font-family);
+      font-weight: var(--rp-ui-base-fw-medium);
+    }
+
+    &.opened {
+      .filter-icon {
+        svg {
+          path {
+            fill: var(--rp-ui-base-topaz-pressed);
+            stroke: var(--rp-ui-base-topaz-pressed);
+          }
+        }
+      }
+
+      .filters-count {
+        color: var(--rp-ui-base-topaz-pressed);
+      }
+    }
+
+    &:not(:disabled):hover {
+      .filter-icon {
+        svg {
+          path {
+            fill: var(--rp-ui-base-topaz-hover);
+            stroke: var(--rp-ui-base-topaz-hover);
+          }
+        }
+      }
+
+      .filters-count {
+        color: var(--rp-ui-base-topaz-hover);
+      }
+    }
+  }
+}
+
+.filter-icon {
+  display: block;
+
+  svg {
+    width: 16px;
+    height: 16px;
+
+    path {
+      fill: var(--rp-ui-base-e-300);
+    }
+  }
+}

--- a/src/components/filtersButton/filtersButton.stories.tsx
+++ b/src/components/filtersButton/filtersButton.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { FiltersButton, FiltersButtonProps } from './filtersButton';
+
+const meta: Meta<typeof FiltersButton> = {
+  title: 'Components/FiltersButton',
+  component: FiltersButton,
+  tags: ['autodocs'],
+  args: {
+    appliedFiltersCount: 0,
+    isOpen: false,
+    disabled: false,
+  },
+  argTypes: {
+    appliedFiltersCount: {
+      control: 'number',
+      description: 'Number of active filters to display in badge',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '0' },
+      },
+    },
+    isOpen: {
+      control: 'boolean',
+      description: 'Whether the filters panel is currently open',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    type: {
+      control: 'select',
+      options: ['button', 'submit'],
+      description: 'HTML button type attribute',
+      table: {
+        type: { summary: "'button' | 'submit'" },
+        defaultValue: { summary: "'button'" },
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the button is disabled',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS class names',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Click event handler',
+      table: {
+        type: { summary: '(event: MouseEvent<HTMLButtonElement>) => void' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default outline icon displayed when no filters are active. Clicking opens the filters panel.',
+      },
+    },
+  },
+};
+
+export const WithAppliedFilters: Story = {
+  args: {
+    appliedFiltersCount: 3,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows a filled icon and count badge when filters are active. Button appearance changes to indicate active state.',
+      },
+    },
+  },
+};
+
+export const Opened: Story = {
+  args: {
+    isOpen: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Visual state when the filters panel is open. Icon color changes to pressed state for visual feedback.',
+      },
+    },
+  },
+};
+
+const FiltersButtonInteractive = (args: FiltersButtonProps) => {
+  const [count, setCount] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <FiltersButton
+      {...args}
+      appliedFiltersCount={count}
+      isOpen={isOpen}
+      onClick={() => {
+        const next = count >= 3 ? 0 : count + 1;
+        setCount(next);
+        setIsOpen((prev) => !prev);
+      }}
+    />
+  );
+};
+
+export const Interactive: Story = {
+  render: (args: FiltersButtonProps) => <FiltersButtonInteractive {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Interactive example cycling through states: no filters → 1 filter → 2 filters → 3 filters → reset.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    appliedFiltersCount: 2,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Button is disabled and cannot be interacted with. Hover states are suppressed and cursor indicates non-interactive state.',
+      },
+    },
+  },
+};

--- a/src/components/filtersButton/filtersButton.tsx
+++ b/src/components/filtersButton/filtersButton.tsx
@@ -1,0 +1,36 @@
+import { ComponentPropsWithRef, forwardRef } from 'react';
+import classNames from 'classnames/bind';
+
+import { FilterFilledIcon, FilterOutlineIcon } from '../icons';
+import styles from './filtersButton.module.scss';
+
+const cx = classNames.bind(styles);
+
+export interface FiltersButtonProps extends Omit<ComponentPropsWithRef<'button'>, 'type'> {
+  appliedFiltersCount?: number;
+  isOpen?: boolean;
+  type?: 'button' | 'submit';
+}
+
+export const FiltersButton = forwardRef<HTMLButtonElement, FiltersButtonProps>(
+  ({ appliedFiltersCount = 0, isOpen = false, className, type = 'button', ...rest }, ref) => {
+    const hasAppliedFilters = appliedFiltersCount > 0;
+    const containerClassName = cx('filters-icon-container', className, {
+      'with-applied': hasAppliedFilters,
+      opened: isOpen,
+    });
+
+    return (
+      <button type={type} className={containerClassName} ref={ref} {...rest}>
+        <span className={cx('filter-icon')}>
+          {hasAppliedFilters ? <FilterFilledIcon /> : <FilterOutlineIcon />}
+        </span>
+        {hasAppliedFilters ? (
+          <span className={cx('filters-count')}>{appliedFiltersCount}</span>
+        ) : null}
+      </button>
+    );
+  },
+);
+
+export default FiltersButton;

--- a/src/components/filtersButton/index.ts
+++ b/src/components/filtersButton/index.ts
@@ -1,0 +1,2 @@
+export { FiltersButton } from './filtersButton';
+export type { FiltersButtonProps } from './filtersButton';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { FieldNumber } from './fieldNumber';
 export { FieldText } from './fieldText';
 export { FieldTextFlex } from './fieldTextFlex';
 export { FileDropArea } from './fileDropArea';
+export { FiltersButton } from './filtersButton';
 export { Modal } from './modal';
 export { MultipleAutocomplete } from './autocompletes/multipleAutocomplete';
 export { Pagination } from './pagination';


### PR DESCRIPTION
## Description
This PR introduces a new reusable `FiltersButton` component to the UI Kit library. The component provides a standardized filter toggle button with visual states for applied filters count and panel open/closed status.

## Component Features

### Props
- `appliedFiltersCount?: number` - Number of active filters to display in badge (default: 0)
- `isOpen?: boolean` - Whether the filters panel is currently open (default: false)
- `type?: 'button' | 'submit'` - HTML button type attribute (default: 'button')
- Extends all standard HTML button props (onClick, disabled, className, etc.)
- Supports `ref` forwarding for DOM access

### Visual States
- **Default state**: Outline icon, no badge
- **With applied filters**: Filled icon, count badge, background highlight
- **Opened state**: Color changes to pressed state for visual feedback
- **Disabled state**: Reduced opacity, no hover effects, not-allowed cursor
- **Hover states**: Icon color transitions for all interactive states

### Storybook Documentation
torybook coverage with explicit argTypes:
- **Default**: No applied filters, panel closed
- **WithAppliedFilters**: Shows badge with count (3 filters)
- **Opened**: Visual state when panel is open
- **Disabled**: Non-interactive state with applied filters
- **Interactive**: Cycling demo (0 → 1 → 2 → 3 → reset)

All props have descriptions and proper type definitions in argTypes.

## Visuals

<img width="978" height="739" alt="image" src="https://github.com/user-attachments/assets/9cd6576b-312d-413b-b7fd-3d9c094f91e0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Filters Button component to the UI library with multiple visual states. The button displays filter icons, shows a count badge when filters are applied, and provides visual feedback for opened filters. Includes styling for hover, focus, and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->