### PR TITLE
EPMRPP-108981 || Fix setting margin logic in SidePanel. Allow closing SidePanel by pressing ESC

### DIFF
--- a/src/components/sidePanel/sidePanel.module.scss
+++ b/src/components/sidePanel/sidePanel.module.scss
@@ -40,6 +40,10 @@
 .header-section {
     flex-shrink: 0;
     margin-bottom: 16px;
+
+    &.compact {
+        margin-bottom: 8px;
+    }
 }
 
 .header {

--- a/src/components/sidePanel/sidePanel.tsx
+++ b/src/components/sidePanel/sidePanel.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useId } from 'react';
+import { ReactNode, useEffect, useId } from 'react';
 import classNames from 'classnames/bind';
+import { KeyCodes } from '@common/constants/keyCodes';
 import { CloseIcon } from '@components/icons';
 import { BaseIconButton } from '@components/baseIconButton';
 import styles from './sidePanel.module.scss';
@@ -39,6 +40,28 @@ export const SidePanel = ({
     onClose?.();
   };
 
+  useEffect(() => {
+    if (!isOpen || !onClose) {
+      return;
+    }
+
+    const onKeydown = (event: KeyboardEvent) => {
+      const { keyCode } = event;
+
+      if (keyCode === KeyCodes.ESCAPE_KEY_CODE) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', onKeydown, false);
+
+    return () => {
+      document.removeEventListener('keydown', onKeydown, false);
+    };
+  }, [isOpen, onClose]);
+
+  const hasHeaderOrDescription = !!(headerComponent || descriptionComponent);
+
   return (
     <aside
       className={cx('side-panel', `side-${side}`, { active: isOpen }, className)}
@@ -49,7 +72,7 @@ export const SidePanel = ({
       style={{ top, height: `calc(100vh - ${top}px)` }}
       tabIndex={-1}
     >
-      <div className={cx('header-section')}>
+      <div className={cx('header-section', { compact: !hasHeaderOrDescription })}>
         {(headerComponent || title) && (
           <div className={cx('header')}>
             {title ? (


### PR DESCRIPTION
### Description

Changes in SidePanel:

* Decrease margin from 16px to 8px in case of `headerComponent` and `descriptionComponent` are empty
* Close panel by pressing ESC



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard support to dismiss the side panel by pressing the Escape key for improved accessibility.

* **Style**
  * Refined header styling with a more compact layout when no title or description content is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->