### PR TITLE
EPMRPP-108981 || Add additional props tooltipPortalRoot and tooltipZIndex

### DIFF
--- a/src/components/dropdown/dropdown.stories.tsx
+++ b/src/components/dropdown/dropdown.stories.tsx
@@ -191,3 +191,79 @@ export const NestedMultiSelect: Story = {
     onClear: () => {},
   },
 };
+
+export const WithTooltipPortal: Story = {
+  render: (args: DropdownProps) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [selectedValues, setSelectedValues] = useState<DropdownValue | DropdownValue[]>([]);
+
+    return (
+      <div className="dropdown-default" style={{ width: '300px' }}>
+        <p style={{ marginBottom: '16px' }}>
+          This example demonstrates tooltip rendering in a portal to prevent clipping when the
+          dropdown is inside a container with overflow hidden (e.g., SidePanel).
+        </p>
+        <Dropdown
+          {...args}
+          onChange={(nextValue) => {
+            setSelectedValues(nextValue);
+          }}
+          value={selectedValues}
+          tooltipPortalRoot={document.body}
+        />
+      </div>
+    );
+  },
+  args: {
+    options: [
+      {
+        value: 'very-long-option-1',
+        label:
+          'Product bug, Critical, Automation bug, Kotlin, Automation bug with very-very long defect type name',
+      },
+      {
+        value: 'very-long-option-2',
+        label: 'Another extremely long option name that will be truncated and show tooltip',
+      },
+      { value: 'option-3', label: 'Option 3' },
+      { value: 'option-4', label: 'Option 4' },
+    ],
+    multiSelect: true,
+    placeholder: 'Select value',
+    clearable: true,
+    onClear: () => {},
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `const [selectedValues, setSelectedValues] = useState([]);
+
+return (
+  <div style={{ width: '300px' }}>
+    <Dropdown
+      options={[
+        {
+          value: 'very-long-option-1',
+          label: 'Product bug, Critical, Automation bug, Kotlin, Automation bug with very-very long defect type name',
+        },
+        {
+          value: 'very-long-option-2',
+          label: 'Another extremely long option name that will be truncated and show tooltip',
+        },
+        { value: 'option-3', label: 'Option 3' },
+        { value: 'option-4', label: 'Option 4' },
+      ]}
+      multiSelect
+      placeholder="Select value"
+      clearable
+      value={selectedValues}
+      onChange={(nextValue) => setSelectedValues(nextValue)}
+      tooltipPortalRoot={document.body}
+    />
+  </div>
+);`,
+        language: 'tsx',
+      },
+    },
+  },
+};

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -81,6 +81,10 @@ export interface DropdownProps {
   onClear?: () => void;
   /** ARIA label for the clear button */
   clearButtonAriaLabel?: string;
+  /** Portal root element for tooltip rendering (e.g., document.body to prevent clipping) */
+  tooltipPortalRoot?: Element;
+  /** Z-index for tooltip when rendered in portal (default: 9) */
+  tooltipZIndex?: number;
 }
 
 // DS link - https://www.figma.com/file/gjYQPbeyf4YsH3wZiVKoaj/%F0%9F%9B%A0-RP-DS-6?type=design&node-id=3424-12207&mode=design&t=dDq6moPaTzQLviS1-0
@@ -116,6 +120,8 @@ export const Dropdown: FC<DropdownProps> = ({
   clearable = false,
   onClear = () => {},
   clearButtonAriaLabel = 'Clear selection',
+  tooltipPortalRoot,
+  tooltipZIndex,
 }): ReactElement => {
   const [opened, setOpened] = useState(false);
   const containerRef = useRef(null);
@@ -534,7 +540,13 @@ export const Dropdown: FC<DropdownProps> = ({
     }
 
     return (
-      <Tooltip content={formattedValue} placement="top" wrapperClassName={cx('value-tooltip')}>
+      <Tooltip
+        content={formattedValue}
+        placement="top"
+        wrapperClassName={cx('value-tooltip')}
+        portalRoot={tooltipPortalRoot}
+        zIndex={tooltipZIndex}
+      >
         {contentNode}
       </Tooltip>
     );


### PR DESCRIPTION
# Add tooltip portal support to Dropdown component

## Summary

This PR adds support for rendering tooltips in a portal to prevent clipping when the `Dropdown` component is used inside containers with `overflow: hidden` (e.g., `SidePanel`, modals, or other scrollable containers).

## Problem

When a `Dropdown` component with truncated values is placed inside a container with `overflow: hidden`, the tooltip that appears on hover gets clipped by the container's boundaries, making it partially or completely invisible to users.

## Solution

Added two new optional props to the `Dropdown` component:
- `tooltipPortalRoot?: Element` - Specifies the portal root element where the tooltip should be rendered (e.g., `document.body` or a dedicated tooltip container)
- `tooltipZIndex?: number` - Allows customizing the z-index of the tooltip when rendered in a portal (defaults to 9 if not specified)


## Usage

```tsx
// Render tooltip in document.body to prevent clipping
<Dropdown
  options={options}
  value={value}
  tooltipPortalRoot={document.body}
  tooltipZIndex={9999}
/>

// Or use a dedicated tooltip container
const tooltipRoot = document.getElementById('tooltip-root');
<Dropdown
  options={options}
  value={value}
  tooltipPortalRoot={tooltipRoot}
/>
```

## Notes

- The `tooltipPortalRoot` prop is optional. If not provided, the tooltip will render in its default location (within the component tree)
- The `tooltipZIndex` prop is optional. If not provided, the tooltip will use its default z-index (9)
- When using portals, ensure the portal root element exists in the DOM and has appropriate z-index styling if needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Dropdown component now supports custom tooltip portal configuration, allowing control over tooltip rendering location and stacking order for improved visibility in complex layouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->