### PR TITLE
EPMRPP-108424 || Fix modal closing when clicking dropdown option in portal

### DIFF
--- a/src/common/hooks/useOnClickOutside.ts
+++ b/src/common/hooks/useOnClickOutside.ts
@@ -1,8 +1,13 @@
 import { useEffect, RefObject } from 'react';
 
+export interface UseOnClickOutsideOptions {
+  ignoreSelectors?: string[];
+}
+
 export function useOnClickOutside<T extends HTMLElement = HTMLDivElement>(
   ref: RefObject<T>,
   handler?: (e?: MouseEvent) => void,
+  options?: UseOnClickOutsideOptions,
 ) {
   useEffect(() => {
     if (!handler) {
@@ -11,7 +16,14 @@ export function useOnClickOutside<T extends HTMLElement = HTMLDivElement>(
 
     const listener = (event: MouseEvent) => {
       if (ref && ref.current && !ref.current.contains(event.target as Node)) {
-        handler(event);
+        const target = event.target as HTMLElement;
+        const shouldIgnore = options?.ignoreSelectors?.some((selector) =>
+          target?.closest(selector),
+        );
+
+        if (!shouldIgnore) {
+          handler(event);
+        }
       }
     };
 
@@ -20,5 +32,5 @@ export function useOnClickOutside<T extends HTMLElement = HTMLDivElement>(
     return () => {
       document.removeEventListener('pointerdown', listener);
     };
-  }, [ref, handler]);
+  }, [ref, handler, options]);
 }

--- a/src/common/hooks/useOnClickOutside.ts
+++ b/src/common/hooks/useOnClickOutside.ts
@@ -1,4 +1,4 @@
-import { useEffect, RefObject } from 'react';
+import { useEffect, useRef, RefObject } from 'react';
 
 export interface UseOnClickOutsideOptions {
   ignoreSelectors?: string[];
@@ -9,6 +9,12 @@ export function useOnClickOutside<T extends HTMLElement = HTMLDivElement>(
   handler?: (e?: MouseEvent) => void,
   options?: UseOnClickOutsideOptions,
 ) {
+  const optionsRef = useRef(options);
+
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+
   useEffect(() => {
     if (!handler) {
       return undefined;
@@ -17,7 +23,7 @@ export function useOnClickOutside<T extends HTMLElement = HTMLDivElement>(
     const listener = (event: MouseEvent) => {
       if (ref && ref.current && !ref.current.contains(event.target as Node)) {
         const target = event.target as HTMLElement;
-        const shouldIgnore = options?.ignoreSelectors?.some((selector) =>
+        const shouldIgnore = optionsRef.current?.ignoreSelectors?.some((selector) =>
           target?.closest(selector),
         );
 
@@ -32,5 +38,5 @@ export function useOnClickOutside<T extends HTMLElement = HTMLDivElement>(
     return () => {
       document.removeEventListener('pointerdown', listener);
     };
-  }, [ref, handler, options]);
+  }, [ref, handler]);
 }

--- a/src/components/dropdown/constants.ts
+++ b/src/components/dropdown/constants.ts
@@ -14,3 +14,5 @@ export enum EventName {
 }
 
 export const SCROLLBARS_AUTO_HEIGHT_MAX = 216;
+
+export const DROPDOWN_PORTAL_MENU_ATTR = 'data-dropdown-portal-menu';

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -28,6 +28,7 @@ import {
   CLOSE_DROPDOWN_KEY_CODES,
   EventName,
   SCROLLBARS_AUTO_HEIGHT_MAX,
+  DROPDOWN_PORTAL_MENU_ATTR,
 } from './constants';
 import {
   calculateDefaultIndex,
@@ -447,6 +448,7 @@ export const Dropdown: FC<DropdownProps> = ({
   // Prevent page scrolling only during initial dropdown opening when rendered in a portal
   // Scroll lock is active for a short period (300ms) to prevent browser auto-scroll behavior
   // After that, normal scrolling is allowed while dropdown remains open
+
   useLayoutEffect(() => {
     if (!opened || !menuPortalRoot) {
       return;
@@ -776,9 +778,13 @@ export const Dropdown: FC<DropdownProps> = ({
               style={menuStyle}
               className={cx(
                 'select-list',
-                { opened, 'limited-width': isListWidthLimited },
+                {
+                  opened,
+                  'limited-width': isListWidthLimited,
+                },
                 selectListClassName,
               )}
+              {...(menuPortalRoot && { [DROPDOWN_PORTAL_MENU_ATTR]: '' })}
               {...getMenuProps({
                 onKeyDown: handleKeyDownMenu,
               })}

--- a/src/components/dropdown/index.ts
+++ b/src/components/dropdown/index.ts
@@ -1,5 +1,6 @@
 import { Dropdown } from './dropdown';
 
 export { Dropdown };
+export { DROPDOWN_PORTAL_MENU_ATTR } from './constants';
 
 export default Dropdown;

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState, FC } from 'react';
+import { ReactNode, useEffect, useMemo, useRef, useState, FC } from 'react';
 import { Scrollbars } from 'rc-scrollbars';
 import { motion, AnimatePresence } from 'framer-motion';
 import classNames from 'classnames/bind';
@@ -116,9 +116,14 @@ export const Modal: FC<ModalProps> = ({
     return () => document.removeEventListener('keydown', onKeydown, false);
   }, []);
 
-  useOnClickOutside(modalRef, allowCloseOutside ? closeModal : undefined, {
-    ignoreSelectors: [`[${DROPDOWN_PORTAL_MENU_ATTR}]`],
-  });
+  const clickOutsideOptions = useMemo(
+    () => ({
+      ignoreSelectors: [`[${DROPDOWN_PORTAL_MENU_ATTR}]`],
+    }),
+    [],
+  );
+
+  useOnClickOutside(modalRef, allowCloseOutside ? closeModal : undefined, clickOutsideOptions);
 
   return (
     <AnimatePresence onExitComplete={onClose}>

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -3,6 +3,7 @@ import { Scrollbars } from 'rc-scrollbars';
 import { motion, AnimatePresence } from 'framer-motion';
 import classNames from 'classnames/bind';
 import { useOnClickOutside, useWindowResize } from '@common/hooks';
+import { DROPDOWN_PORTAL_MENU_ATTR } from '@components/dropdown';
 import { KeyCodes } from '@common/constants/keyCodes';
 import { ButtonProps } from '@components/button';
 import { ModalContent } from './modalContent';
@@ -115,7 +116,9 @@ export const Modal: FC<ModalProps> = ({
     return () => document.removeEventListener('keydown', onKeydown, false);
   }, []);
 
-  useOnClickOutside(modalRef, allowCloseOutside ? closeModal : undefined);
+  useOnClickOutside(modalRef, allowCloseOutside ? closeModal : undefined, {
+    ignoreSelectors: [`[${DROPDOWN_PORTAL_MENU_ATTR}]`],
+  });
 
   return (
     <AnimatePresence onExitComplete={onClose}>


### PR DESCRIPTION
# Fix modal closing when clicking dropdown option in portal

## Problem

When a Dropdown component uses `menuPortalRoot` to render its menu in a portal (e.g., inside a Modal), clicking on a dropdown option causes the modal to close unexpectedly. This happens because the `useOnClickOutside` hook in Modal treats clicks on portal-rendered elements as "outside clicks".

## Solution

Enhanced the `useOnClickOutside` hook to support ignoring clicks on specific elements via CSS selectors. The Dropdown component now adds a data attribute (`data-dropdown-portal-menu`) to portal-rendered menus, and Modal uses this attribute to ignore clicks on dropdown menus.

## Changes

### Modified Files

**`src/common/hooks/useOnClickOutside.ts`**
- Added `UseOnClickOutsideOptions` interface with `ignoreSelectors?: string[]` property
- Updated hook to accept optional `options` parameter
- Added logic to check if click target matches any of the `ignoreSelectors` before calling handler

**`src/components/dropdown/constants.ts`**
- Added `DROPDOWN_PORTAL_MENU_ATTR = 'data-dropdown-portal-menu'` constant

**`src/components/dropdown/dropdown.tsx`**
- Added `data-dropdown-portal-menu` attribute to portal-rendered menu element
- Imported and used `DROPDOWN_PORTAL_MENU_ATTR` constant

**`src/components/dropdown/index.ts`**
- Exported `DROPDOWN_PORTAL_MENU_ATTR` constant for use in other components

**`src/components/modal/modal.tsx`**
- Updated `useOnClickOutside` call to include `ignoreSelectors` option
- Uses `DROPDOWN_PORTAL_MENU_ATTR` constant to ignore clicks on portal-rendered dropdown menus

## Technical Details

The solution uses a flexible selector-based approach:

1. **Dropdown** adds `data-dropdown-portal-menu` attribute to portal-rendered menus
2. **useOnClickOutside** checks if click target matches any selector in `ignoreSelectors` array
3. **Modal** passes the data attribute selector to `useOnClickOutside` to ignore dropdown menu clicks

This approach is extensible - other components can use `ignoreSelectors` to ignore clicks on any portal-rendered elements.

## Usage Example

```tsx
// In Modal component
import { DROPDOWN_PORTAL_MENU_ATTR } from '@components/dropdown';

useOnClickOutside(modalRef, closeModal, {
  ignoreSelectors: [`[${DROPDOWN_PORTAL_MENU_ATTR}]`],
});
```

## Benefits

1. **Fixes modal closing bug** - Modals no longer close when clicking dropdown options in portals
2. **Flexible solution** - `ignoreSelectors` can be used for any portal-rendered elements
3. **Backward compatible** - Existing `useOnClickOutside` calls work without changes
4. **Maintainable** - Uses a constant for the data attribute name



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page auto-scrolling when dropdowns open in portal containers.
  * Prevented unintended modal closure when interacting with dropdown menus.

* **New Features**
  * Enhanced click-outside handling with options to ignore specified UI elements.
  * Added a public attribute to mark dropdown portal menus for improved interaction handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->