### PR TITLE
EPMRPP-109798 || Fix Dropdown component bugs and improve accessibility

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -374,7 +374,6 @@ export const Dropdown: FC<DropdownProps> = ({
     getItemProps,
     setHighlightedIndex,
     highlightedIndex,
-    selectedItem,
   } = useSelect<DropdownOptionType>({
     items: selectableOptions,
     itemToString: (item): string => (item?.label ? String(item.label) : placeholder) || '',
@@ -655,9 +654,7 @@ export const Dropdown: FC<DropdownProps> = ({
               index,
             })}
             multiSelect={multiSelect}
-            selected={
-              multiSelect ? isMultiChecked : option.value === (selectedItem?.value ?? selectedItem)
-            }
+            selected={multiSelect ? isMultiChecked : option.value === value}
             option={{ title: option.label, ...option }}
             highlightHovered={highlightedIndex === index && eventName !== EventName.ON_CLICK}
             render={renderOption}
@@ -730,7 +727,15 @@ export const Dropdown: FC<DropdownProps> = ({
 
   return (
     <div ref={containerRef} className={cx('container', className)} title={title}>
-      {label && <FieldLabel {...getLabelProps()}>{label}</FieldLabel>}
+      {label && (
+        <FieldLabel
+          {...getLabelProps()}
+          onClick={() => !disabled && onDropdownClick()}
+          style={{ cursor: disabled ? 'default' : 'pointer' }}
+        >
+          {label}
+        </FieldLabel>
+      )}
       <div
         {...restToggleButtonProps}
         role="button"

--- a/src/components/fieldText/fieldText.module.scss
+++ b/src/components/fieldText/fieldText.module.scss
@@ -38,7 +38,6 @@
 .icon-container-end {
   @extend .icon-container;
   margin-left: 12px;
-  justify-content: flex-end;
 }
 
 .icon-container-additional {

--- a/src/components/fieldText/fieldText.module.scss
+++ b/src/components/fieldText/fieldText.module.scss
@@ -24,13 +24,11 @@
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  width: 22px;
-  height: 22px;
 }
 
 .icon-container-start {
   @extend .icon-container;
-  margin-right: 4px;
+  margin-right: 12px;
 
   .collapsed & {
     cursor: pointer;
@@ -39,12 +37,13 @@
 
 .icon-container-end {
   @extend .icon-container;
-  margin-left: 4px;
+  margin-left: 12px;
+  justify-content: flex-end;
 }
 
 .icon-container-additional {
   @extend .icon-container;
-  margin-left: 4px;
+  margin-left: 12px;
 }
 
 .field {


### PR DESCRIPTION
# Fix Dropdown component bugs and improve accessibility

## Summary

This PR fixes two bugs in the Dropdown component and improves accessibility by making labels clickable. Additionally, it includes minor styling improvements for the FieldText component.

## Changes

### Dropdown Component (`src/components/dropdown/dropdown.tsx`)

#### Bug Fix: Selected option remains highlighted after clear

**Problem:** When a user selected an option in a single-select Dropdown and then clicked the clear button, the dropdown was cleared correctly. However, when reopening the dropdown, the previously selected option still appeared highlighted/selected visually, even though the value was cleared.

**Root Cause:** The component was using `selectedItem` from `useSelect` hook to determine if an option should be marked as selected. The `selectedItem` is initialized once when the component is created and doesn't update when the `value` prop changes (e.g., after clearing). This caused a mismatch between the actual value and the visual selection state.

**Solution:**
- Changed the selection logic for single-select mode to use direct comparison with the `value` prop instead of `selectedItem`
- Removed unused `selectedItem` variable from the `useSelect` destructuring
- For multi-select mode, the existing logic using `isMultiChecked` (which correctly uses `selectedValuesSet` based on `value`) remains unchanged


#### Accessibility Improvement: Label click opens dropdown

**Problem:** When a Dropdown component has a label, clicking on the label did not open the dropdown menu, which violates accessibility standards. According to HTML/ARIA standards, clicking on a `<label>` should activate the associated form control.

**Root Cause:** The `getLabelProps()` from `downshift` returns `htmlFor` attribute that should link the label to the toggle button via `id`. However, in HTML, `<label htmlFor="id">` only works with native form elements (`<input>`, `<select>`, `<button>`, `<textarea>`). It does NOT work with `<div>` elements, even if they have `role="button"`, `tabIndex`, and `id`. This is a browser limitation - clicking on `<label htmlFor="divId">` does not activate `<div id="divId">`.

**Solution:**
- Added an `onClick` handler to `FieldLabel` that calls `onDropdownClick()` when the label is clicked
- Added `cursor: pointer` style to visually indicate that the label is clickable (when not disabled)
- This ensures proper accessibility behavior: clicking the label now opens/closes the dropdown

### FieldText Component (`src/components/fieldText/fieldText.module.scss`)

#### Styling improvements for icon containers

- Removed fixed dimensions (`width: 22px; height: 22px;`) from `.icon-container` base class to allow more flexible sizing
- Increased spacing for icon containers:
  - `.icon-container-start`: Changed `margin-right` from `4px` to `12px`
  - `.icon-container-end`: Changed `margin-left` from `4px` to `12px` 
  - `.icon-container-additional`: Changed `margin-left` from `4px` to `12px`

These changes improve visual spacing and alignment of icons within the FieldText component.


## Impact

- **Breaking Changes:** None
- **Accessibility:** Improved - labels are now properly clickable
- **Bug Fixes:** Fixed visual bug where cleared options appeared selected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dropdown labels are now interactive and clickable to toggle the dropdown menu
  * Icon spacing in text fields has been adjusted for improved visual alignment and layout consistency
  * Enhanced dropdown selection tracking for more stable behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->