### PR TITLE
EPMRPP-109880 || Fix SingleAutocomplete clear button to only show with selected values

### DIFF
--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -172,6 +172,16 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
 
         const downshiftValue = inputValue ?? '';
 
+        const { onClear: inputOnClear, clearable: inputClearable, ...restInputProps } = inputProps;
+
+        const hasSelectedValue = value !== null;
+        const shouldShowClear = inputClearable && hasSelectedValue;
+
+        const handleClear = () => {
+          selectItem(null as T);
+          inputOnClear?.();
+        };
+
         return (
           <>
             <div className={cx('input-wrapper')} {...modifiedRootProps}>
@@ -225,7 +235,9 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
                   isRequired,
                   touched,
                   error,
-                  ...inputProps,
+                  ...restInputProps,
+                  clearable: shouldShowClear,
+                  onClear: shouldShowClear ? handleClear : inputOnClear,
                   endIcon:
                     isDropdownMode && !icon ? (
                       <button

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -177,9 +177,9 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
         const hasSelectedValue = value !== null;
         const shouldShowClear = inputClearable && hasSelectedValue;
 
-        const handleClear = () => {
+        const handleClear: ComponentProps<typeof FieldText>['onClear'] = (...args) => {
           selectItem(null as T);
-          inputOnClear?.();
+          inputOnClear?.(...args);
         };
 
         return (


### PR DESCRIPTION
### Summary

This PR updates the `SingleAutocomplete` component behavior so that the clear button is shown **only when a value is actually selected**, not when the user has just typed text that is not committed as a selected value. The change affects a single file: `src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx`.

### Details

- **Before**
  - The clear button visibility was effectively driven by the input text (`inputValue` via `FieldText`), so it could appear even when no `selectedItem` was set (user typed something, but nothing was selected).
  - This created inconsistent UX between different usage scenarios (string vs object options) and blurred the semantics of “clearing” a *selected* value vs just temporary input.

- **After**
  - `SingleAutocomplete` now derives clear button visibility from the presence of a selected value:
    - The clear button is shown only if:
      - `inputProps.clearable` is `true`, **and**
      - `value !== null` (there is a selected item).
    - When the clear button is clicked:
      - `selectItem(null)` is called to clear the selection.
      - The original `inputProps.onClear` callback is invoked (if provided).
  - Temporary input (`inputValue`) without a selected value no longer triggers the clear button to appear; such input is discarded on blur according to the existing logic (no selected option → `selectedItem` remains `null`).

### Rationale

- Aligns with UX recommendations: the clear control should reflect and operate on the *selected value*, not on transient, non-committed input.
- Reduces visual noise and potential confusion: the clear button appears only when there is something meaningful to clear from the control’s “committed” state.
- Keeps keyboard/text editing as the primary way to clear uncommitted typed input.

### Backward Compatibility

- Existing consumers that:
  - **Rely on `clearable` + a selected value**: behavior remains consistent and becomes more predictable (clear always removes the selected value).
  - **Expect clear to appear on raw text input without a selected value**: behavior changes; the clear button will no longer appear in that state, per the new UX decision.
- The external API (`SingleAutocompleteProps`) is unchanged; the behavior change is internal and limited to how `clearable` is applied to `FieldText`.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autocomplete fields now show a clear action when an item is selected, allowing users to reset their choice with one action while preserving existing focus, blur, and dropdown behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->