### PR TITLE
EPMRPP-108236 || Add menuClassName prop to MultipleAutocomplete for сustom styling

### DIFF
--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.stories.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.stories.tsx
@@ -52,6 +52,7 @@ const TEST_DATA_OBJECTS: Partial<
   },
   maxLength: null,
   customClass: '',
+  menuClassName: '',
   parseInputValueFn: null,
   dataAutomationId: '',
 };
@@ -88,6 +89,7 @@ const TEST_DATA_STRINGS: Partial<
   mobileDisabled: false,
   maxLength: null,
   customClass: '',
+  menuClassName: '',
   parseInputValueFn: null,
   dataAutomationId: '',
 };

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -86,6 +86,7 @@ export interface MultipleAutocompleteProps<T> {
   customNoMatchesMessage?: string;
   useFixedPositioning?: boolean;
   newItemButtonText?: string;
+  menuClassName?: string;
 }
 
 export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompleteProps<T>) => {
@@ -125,6 +126,7 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
     renderCustomSelectedItem,
     useFixedPositioning,
     newItemButtonText = '',
+    menuClassName = '',
     ...props
   } = componentsProps;
 
@@ -362,6 +364,7 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
                 parseValueToString={parseValueToString}
                 createWithoutConfirmation={createWithoutConfirmation}
                 options={filteredOptions}
+                className={menuClassName}
                 {...props}
               />
             </div>


### PR DESCRIPTION
# Feature: Add menuClassName prop to MultipleAutocomplete component

## Description
This PR adds a new `menuClassName` prop to the `MultipleAutocomplete` component, allowing developers to apply custom CSS classes directly to the dropdown menu (`<ul>` element) without breaking component encapsulation.

## Problem
Previously, developers had to style the internal menu structure through wrapper elements or use fragile CSS selectors that target internal DOM structure. This approach was error-prone and could break with future component updates.

## Solution
Added a dedicated `menuClassName` prop that:
- Accepts custom CSS class names
- Applies them directly to the `AutocompleteMenu` component
- Uses the existing `className` prop of `AutocompleteMenu` internally
- Maintains full TypeScript type safety


### Storybook Updates (`multipleAutocomplete.stories.tsx`)
Added `menuClassName: ''` to both test data objects to maintain Storybook compatibility.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `menuClassName` property to MultipleAutocomplete component, enabling custom styling of dropdown menus for enhanced visual customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->