### PR TITLE
EPMRPP-110085 || Add isAllExpandedByDefault and expandAllTooltip pros for table

### DIFF
--- a/src/components/table/table.module.scss
+++ b/src/components/table/table.module.scss
@@ -216,7 +216,7 @@ $PADDING_VERTICAL-LARGE: 30px;
     padding: 0 16px;
   }
 
-  &:not(.action-menu-cell) {
+  &:not(.action-menu-cell):not(.expand-cell) {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -272,8 +272,22 @@ $PADDING_VERTICAL-LARGE: 30px;
       background: none;
       border: none;
       padding: 0;
-      width: 32px;
+      width: 16px;
+      margin-left: 16px;
       cursor: pointer;
+    }
+
+    .expand-all-tooltip-wrapper {
+      width: 16px;
+      margin-left: 16px;
+
+      button {
+        margin-left: 0;
+      }
+    }
+
+    .expand-all-tooltip-content {
+      width: max-content;
     }
 
     svg {
@@ -368,6 +382,5 @@ $PADDING_VERTICAL-LARGE: 30px;
     position: sticky;
     z-index: 1;
     background: var(--rp-ui-color-field-bg);
-
   }
 }

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -621,6 +621,140 @@ export const ExpandableRows: Story = {
             }
             setExpandedRows(newExpandedRows);
           }}
+          onToggleAllRowsExpansion={() => {
+            if (expandedRows.size === expandableData.length) {
+              setExpandedRows(new Set());
+            } else {
+              const allRows = new Set(expandableData.map((item) => item.id));
+              setExpandedRows(allRows);
+            }
+          }}
+          selectedRowIds={[...checkedRows]}
+          onToggleRowSelection={(id) => {
+            const newCheckedRows = new Set(checkedRows);
+            if (newCheckedRows.has(id)) {
+              newCheckedRows.delete(id);
+            } else {
+              newCheckedRows.add(id);
+            }
+            setCheckedRows(newCheckedRows);
+          }}
+          onToggleAllRowsSelection={() => {
+            if (checkedRows.size === expandableData.length) {
+              setCheckedRows(new Set());
+            } else {
+              const allRows = new Set(expandableData.map((item) => item.id));
+              setCheckedRows(allRows);
+            }
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    selectable: true,
+  },
+};
+
+export const ExpandableRowsWithDefaultState: Story = {
+  render: (args: TableComponentProps) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [expandedRows, setExpandedRows] = useState<Set<number | string>>(new Set([1, 2, 3, 4]));
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isAllExpandedByDefault, setIsAllExpandedByDefault] = useState<boolean>(true);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [checkedRows, setCheckedRows] = useState<Set<number | string>>(new Set([]));
+
+    const expandableData: RowData[] = [
+      {
+        id: 1,
+        name: 'Anna Smith',
+        age: 25,
+        city: 'New York',
+        department: 'Engineering',
+        email: 'anna.smith@example.com',
+      },
+      {
+        id: 2,
+        name: 'Mike Davis',
+        age: 32,
+        city: 'San Francisco',
+        department: 'Design',
+        email: 'mike.davis@example.com',
+      },
+      {
+        id: 3,
+        name: 'Sarah Wilson',
+        age: 28,
+        city: 'Los Angeles',
+        department: 'Marketing',
+        email: 'sarah.wilson@example.com',
+      },
+      {
+        id: 4,
+        name: 'John Brown',
+        age: 35,
+        city: 'Chicago',
+        department: 'Sales',
+        email: 'john.brown@example.com',
+      },
+    ];
+
+    const expandableFixedColumns: FixedColumn[] = [
+      { key: 'age', header: 'Age', align: 'right', width: 80 },
+      { key: 'department', header: 'Department', width: 120 },
+      { key: 'city', header: 'City', width: 120 },
+    ];
+    const expandablePrimaryColumns: Column[] = [
+      {
+        key: 'name',
+        header: 'Name',
+      },
+    ];
+
+    const expandAllTooltip = isAllExpandedByDefault
+      ? 'Expanded by default'
+      : 'Collapsed by default';
+
+    return (
+      <div style={{ minWidth: '800px', maxWidth: '1300px' }}>
+        <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', color: '#333' }}>
+          Expandable Rows with Default State
+        </h3>
+        <p style={{ margin: '0 0 16px 0', fontSize: '14px', color: '#666' }}>
+          Demonstrates <strong>isAllExpandedByDefault</strong> and <strong>expandAllTooltip</strong>{' '}
+          props. The expandAll icon shows the default state regardless of individual row states.
+          Hover over the expandAll icon to see the tooltip.
+        </p>
+        <Table
+          {...args}
+          data={expandableData}
+          primaryColumn={expandablePrimaryColumns}
+          fixedColumns={expandableFixedColumns}
+          isRowsExpandable={true}
+          selectable={true}
+          expandedRowIds={[...expandedRows]}
+          isAllExpandedByDefault={isAllExpandedByDefault}
+          expandAllTooltip={expandAllTooltip}
+          onToggleRowExpansion={(id) => {
+            const newExpandedRows = new Set(expandedRows);
+            if (newExpandedRows.has(id)) {
+              newExpandedRows.delete(id);
+            } else {
+              newExpandedRows.add(id);
+            }
+            setExpandedRows(newExpandedRows);
+          }}
+          onToggleAllRowsExpansion={() => {
+            const newIsAllExpandedByDefault = !isAllExpandedByDefault;
+            setIsAllExpandedByDefault(newIsAllExpandedByDefault);
+
+            if (newIsAllExpandedByDefault) {
+              setExpandedRows(new Set(expandableData.map((item) => item.id)));
+            } else {
+              setExpandedRows(new Set());
+            }
+          }}
           selectedRowIds={[...checkedRows]}
           onToggleRowSelection={(id) => {
             const newCheckedRows = new Set(checkedRows);
@@ -763,6 +897,14 @@ export const CellExpansion: Story = {
                 newExpandedRows.add(id);
               }
               setExpandedRows(newExpandedRows);
+            }}
+            onToggleAllRowsExpansion={() => {
+              if (expandedRows.size === longTextData.length) {
+                setExpandedRows(new Set());
+              } else {
+                const allRows = new Set(longTextData.map((item) => item.id));
+                setExpandedRows(allRows);
+              }
             }}
           />
         </div>

--- a/src/components/table/table.test.tsx
+++ b/src/components/table/table.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@components/checkbox', () => ({
 vi.mock('@components/icons', () => ({
   ArrowDownIcon: () => <div data-testid="arrow-down-icon">↓</div>,
   ArrowUpIcon: () => <div data-testid="arrow-up-icon">↑</div>,
+  ChevronDownDropdownIcon: () => <div data-testid="chevron-down-dropdown-icon">▼</div>,
 }));
 
 describe('Table Component', () => {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames/bind';
 import { ArrowDownIcon, ArrowUpIcon, ChevronDownDropdownIcon } from '@components/icons';
 import { TableComponentProps, FixedColumn, Column, PrimaryColumn } from './types';
 import { Checkbox } from '@components/checkbox';
+import { Tooltip } from '@components/tooltip';
 import {
   getColumnsKeys,
   isPrimaryColumn,
@@ -54,6 +55,8 @@ export const Table: FC<TableComponentProps> = ({
   pinnedColumnKeys = [],
   isRowsExpandable = false,
   expandedRowIds = [],
+  isAllExpandedByDefault,
+  expandAllTooltip,
   onChangeSorting = () => {},
   onToggleRowSelection = () => {},
   onToggleAllRowsSelection = () => {},
@@ -125,6 +128,8 @@ export const Table: FC<TableComponentProps> = ({
   const hasSelectedRows = selectedRowIds?.length > 0;
 
   const isAllRowsExpanded: boolean = data.every((row) => expandedRowIds.includes(row.id));
+  const expandAllIconState =
+    isAllExpandedByDefault !== undefined ? isAllExpandedByDefault : isAllRowsExpanded;
 
   const gridTemplateColumns = getGridTemplateColumns(
     pinnedColumns,
@@ -142,6 +147,14 @@ export const Table: FC<TableComponentProps> = ({
     selectable,
     !!renderRowActions,
     true,
+  );
+
+  const expandAllButton = (
+    <button onClick={handleToggleAllRowsExpansion} aria-label="Toggle all rows expansion">
+      <span className={cx('expand-icon', { expanded: expandAllIconState })}>
+        <ChevronDownDropdownIcon />
+      </span>
+    </button>
   );
 
   return (
@@ -183,11 +196,18 @@ export const Table: FC<TableComponentProps> = ({
         )}
         {isRowsExpandable && (
           <div className={cx('table-header-cell', 'expand-cell')} style={{ left: '0' }}>
-            <button onClick={handleToggleAllRowsExpansion} aria-label="Toggle all rows expansion">
-              <span className={cx('expand-icon', { expanded: isAllRowsExpanded })}>
-                <ChevronDownDropdownIcon />
-              </span>
-            </button>
+            {expandAllTooltip ? (
+              <Tooltip
+                content={expandAllTooltip}
+                placement="top"
+                wrapperClassName={cx('expand-all-tooltip-wrapper')}
+                contentClassName={cx('expand-all-tooltip-content')}
+              >
+                {expandAllButton}
+              </Tooltip>
+            ) : (
+              expandAllButton
+            )}
           </div>
         )}
         {pinnedColumns.map((column, index) => (

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -57,6 +57,8 @@ export interface TableComponentProps {
   isRowsExpandable?: boolean;
   expandedRowIds?: (string | number)[];
   setExpandedRowIds?: Dispatch<SetStateAction<Set<string | number>>>;
+  isAllExpandedByDefault?: boolean;
+  expandAllTooltip?: ReactNode;
   onChangeSorting?: (sortConfig?: SortConfig) => void;
   onToggleRowSelection?: (id: string | number) => void;
   onToggleAllRowsSelection?: () => void;


### PR DESCRIPTION
## Links
[EPMRPP-110085](https://jiraeu.epam.com/browse/EPMRPP-110085)
[EPMRPP-109561](https://jiraeu.epam.com/browse/EPMRPP-109561)

## Visuals
https://github.com/user-attachments/assets/f6ee856a-ed40-4e25-a544-747fb2e8bd0d
<img width="299" height="187" alt="Screenshot 2025-12-02 145222" src="https://github.com/user-attachments/assets/2e97692a-83ed-47ee-ac61-2874ccea78ee" />
<img width="218" height="151" alt="Screenshot 2025-12-02 145233" src="https://github.com/user-attachments/assets/9f006a79-f3f5-48cc-a2f2-21a30d27fe6e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expand-all / collapse-all control with optional tooltip and a configurable default-expanded state.
  * Bulk row selection toggling across stories and table variants.

* **Style**
  * Adjusted expand button and tooltip layout and spacing for tighter alignment and consistent icon sizing.

* **Tests**
  * Extended test mocks to include an additional chevron icon used by the new expand control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->