### PR TITLE
EPMRPP-110013 || Build ui-kit in CommonJS format instead of ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@reportportal/ui-kit",
   "version": "0.0.1-alpha.140",
   "description": "The UI-kit library for ReportPortal Design System.",
-  "type": "module",
   "scripts": {
     "start": "storybook dev -p 6006",
     "build": "tsc && vite build",
@@ -18,14 +17,13 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/components/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/components/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.cjs"
     },
     "./style.css": "./dist/style.css",
     "./common": {
@@ -34,8 +32,8 @@
     },
     "./*": {
       "types": "./dist/components/*/index.d.ts",
-      "import": "./dist/*.js",
-      "default": "./dist/*.js"
+      "require": "./dist/*.cjs",
+      "default": "./dist/*.cjs"
     }
   },
   "peerDependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,8 @@ export default defineConfig(() => ({
     lib: {
       entry: generateEntries(),
       name: 'ui-kit',
-      formats: ['es'] as LibraryFormats[],
+      formats: ['cjs'] as LibraryFormats[], // Changed from 'es' to 'cjs' for Module Federation + SRI compatibility
+      fileName: (format, entryName) => `${entryName}.${format === 'cjs' ? 'cjs' : 'js'}`,
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
# Switch build output from ESM to CommonJS

## Summary

This PR changes the ui-kit build output format from ESM (`"type": "module"`) to CommonJS. This change is required to enable ui-kit sharing via webpack Module Federation in service-ui.

## Problem

Currently, `service-ui` cannot share `@reportportal/ui-kit` via webpack Module Federation due to a compatibility issue with `webpack-subresource-integrity` plugin. When ui-kit (as ESM module) is added to the `shared` configuration, the build fails with:

```
ERROR in webpack-subresource-integrity: Asset xxx.js contains unresolved integrity placeholders
```

As a result, plugins bundle their own copy of ui-kit as a fallback, adding **~500KB** to each plugin's bundle size.

## Root Cause

After investigation, we discovered that ui-kit was the **only ESM module** among all shared dependencies. All other shared modules (react, react-dom, classnames, etc.) are CommonJS. The SubresourceIntegrity plugin fails to resolve integrity hashes for ESM modules in the Module Federation shared scope.

## Changes

- **vite.config.ts**: Changed build format from `['es']` to `['cjs']`
- **package.json**: 
  - Removed `"type": "module"`
  - Updated `main` to `./dist/index.cjs`
  - Updated `exports` paths to use `.cjs` extension

## Impact

- **No breaking changes** for consumers — all imports remain the same:
  ```ts
  import { Button } from '@reportportal/ui-kit';
  ```
- Modern bundlers (webpack, Vite, Rollup) handle CJS modules seamlessly
- Enables **~500KB reduction** in each plugin's bundle size after service-ui update

## Testing

- [x] Build passes (`npm run build`)
- [x] Storybook works (`npm run start`)
- [x] Tested with service-ui (dev mode)
- [x] Tested with plugin-test-execution (Module Federation sharing works)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Library distribution format changed from ES modules to CommonJS.
  * Updated package configuration and build settings to output CommonJS format exclusively, with `.cjs` file extensions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->