### PR TITLE
EPMRPP-109890 || Move a scrollbar outside of modal content

### DIFF
--- a/src/components/modal/modal.module.scss
+++ b/src/components/modal/modal.module.scss
@@ -3,6 +3,7 @@
 $WIDTH-SMALL: 320px;
 $WIDTH-DEFAULT: 480px;
 $WIDTH-LARGE: 720px;
+$SCROLLBAR-WIDTH: 12px;
 
 // TODO: Discuss with UX team. There are no designs for the dark theme, so the theme-independent CSS properties are used
 
@@ -67,10 +68,14 @@ $WIDTH-LARGE: 720px;
   font-weight: var(--rp-ui-base-fw-regular);
   @include font-scale();
   color: var(--rp-ui-base-almost-black);
+}
 
-  &.scrollable{
-    width: calc(100% - 34px);
-  }
+.scrollable-wrapper {
+  margin-right: -$SCROLLBAR-WIDTH;
+}
+
+.scrollable-content {
+  padding-right: $SCROLLBAR-WIDTH;
 }
 
 .size-default {

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -142,14 +142,18 @@ export const Modal: FC<ModalProps> = ({
           >
             <ModalHeader title={title} onClose={closeModal} withDescription={!!description} />
             {scrollable ? (
-              <Scrollbars autoHeight autoHeightMax={getContentMaxHeight()} hideTracksWhenNotNeeded>
-                {description && (
-                  <span className={cx('description', { scrollable: scrollable })}>
-                    {description}
-                  </span>
-                )}
-                <ModalContent scrollable>{children}</ModalContent>
-              </Scrollbars>
+              <div className={cx('scrollable-wrapper')}>
+                <Scrollbars
+                  autoHeight
+                  autoHeightMax={getContentMaxHeight()}
+                  hideTracksWhenNotNeeded
+                >
+                  <div className={cx('scrollable-content')}>
+                    {description && <span className={cx('description')}>{description}</span>}
+                    <ModalContent>{children}</ModalContent>
+                  </div>
+                </Scrollbars>
+              </div>
             ) : (
               <>
                 {description && <span className={cx('description')}>{description}</span>}

--- a/src/components/modal/modalContent/modalContent.module.scss
+++ b/src/components/modal/modalContent/modalContent.module.scss
@@ -9,8 +9,4 @@
   white-space: pre-line;
   word-break: break-word;
   padding: 0 0 16px;
-
-  &.scrollable {
-    width: calc(100% - 34px);
-  }
 }

--- a/src/components/modal/modalContent/modalContent.tsx
+++ b/src/components/modal/modalContent/modalContent.tsx
@@ -1,14 +1,13 @@
-import { ReactNode, FC } from 'react';
+import { ReactNode } from 'react';
 import classNames from 'classnames/bind';
 import styles from './modalContent.module.scss';
 
 const cx = classNames.bind(styles);
 
 interface ModalContentProps {
-  scrollable?: boolean;
   children?: ReactNode;
 }
 
-export const ModalContent: FC<ModalContentProps> = ({ scrollable = false, children }) => (
-  <div className={cx('modal-content', { scrollable: scrollable })}>{children}</div>
+export const ModalContent = ({ children }: ModalContentProps) => (
+  <div className={cx('modal-content')}>{children}</div>
 );


### PR DESCRIPTION
## Summary

**Goal:** Keep content at full width while placing the scrollbar on the right side without overlapping
**Approach:**
1. `rc-scrollbars` sets inline styles on the view element to hide the native browser scrollbar. So it's impossible to position the custom scrollbar outside its parent container - the scrollbar is always rendered within the Scrollbars component boundaries.
2. The current solution is the simplest and the cleanest:
   - The scrollable content margin has been removed to keep the content at full width
   - `.scrollable-wrapper` with `margin-right: -$SCROLLBAR-WIDTH` expands the Scrollbars area into the modal's right padding
   - `.scrollable-content` with `padding-right: $SCROLLBAR-WIDTH` keeps content at the original width
   - The custom scrollbar naturally appears in the expanded zone on the right

## LInks
[EPMRPP-109890](https://jiraeu.epam.com/browse/EPMRPP-109890)

## Visuals
**_Before:_**
<img width="502" height="879" alt="Screenshot 2025-12-15 102708" src="https://github.com/user-attachments/assets/7c0bc94a-2c32-471d-ad19-ad3fefd57aa4" />
  
**_After:_**    
<img width="504" height="870" alt="Screenshot 2025-12-15 102730" src="https://github.com/user-attachments/assets/945da22e-8ab8-4173-b009-67278828383f" />


https://github.com/user-attachments/assets/f1daf711-d89e-48a6-a168-e55dbbb2bff8




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured scrollable modal implementation with improved internal DOM hierarchy and styling approach for better code maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->