### PR TITLE
EPMRPP-107833 || Clip resize handle for last column

### DIFF
--- a/src/components/table/table.module.scss
+++ b/src/components/table/table.module.scss
@@ -58,9 +58,15 @@ $PADDING_VERTICAL-LARGE: 30px;
     }
   }
 
-  &.resizable:not(.horizontally-scrollable) {
-    min-width: fit-content;
-    padding: 0 3px;
+  &.resizable {
+    .resizable-column:last-child {
+      overflow-x: hidden;
+    }
+
+    &:not(.horizontally-scrollable) {
+      min-width: fit-content;
+      padding: 0 3px;
+    }
   }
 }
 
@@ -235,7 +241,7 @@ $PADDING_VERTICAL-LARGE: 30px;
   }
 
   &:not(.action-menu-cell):not(.expand-cell) {
-   &:not(.table-header-cell) {
+    &:not(.table-header-cell) {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -132,6 +132,7 @@ export const Table: FC<TableComponentProps> = ({
       onResizeStop={handleResizeStop(column.key)}
       minConstraints={[minColumnWidth, 0]}
       maxConstraints={[maxColumnWidth, 0]}
+      className={cx('resizable-column')}
     >
       {headerCell}
     </Resizable>


### PR DESCRIPTION
## Changes
1. Fixed the default horizontal scrollbar in resizable tables: the resize handle was causing a few extra pixels of overflow; 
Now the last resizable header wrapper clips overflow so the handle doesn’t trigger horizontal scroll by default.

## Visuals
_Note: the handle is visible on hover_  

**_Before:_**  
<img width="1840" height="595" alt="Screenshot 2025-12-17 165517" src="https://github.com/user-attachments/assets/b61d751b-2eb2-47f5-8078-a2a58c7bddc2" />  
**_After:_**  
<img width="1836" height="292" alt="Screenshot 2025-12-17 170211" src="https://github.com/user-attachments/assets/80ee9c53-5c43-40d4-acff-d21c21e9a48a" />

**_Before:_**  
<img width="721" height="372" alt="Screenshot 2025-12-17 165731" src="https://github.com/user-attachments/assets/3b9845bb-48cd-4754-9301-aea6cd5ed4a6" />
**_After:_**  
<img width="647" height="331" alt="Screenshot 2025-12-17 165751" src="https://github.com/user-attachments/assets/7d8e647f-45c5-493b-bbe8-b4768c377101" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced resizable table column styling with improved overflow handling. The last column in resizable mode now properly hides excess content while maintaining proper padding and minimum width constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->