### PR TITLE
EPMRPP-110935 || Fix resizable primary column width

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -181,6 +181,7 @@ export const Table: FC<TableComponentProps> = ({
     !!renderRowActions,
     false,
     isResizable ? columnWidths : undefined,
+    isResizable,
   );
 
   const headerGridTemplateColumns = getGridTemplateColumns(
@@ -191,6 +192,7 @@ export const Table: FC<TableComponentProps> = ({
     !!renderRowActions,
     true,
     isResizable ? columnWidths : undefined,
+    isResizable,
   );
 
   const expandAllButton = (

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -47,6 +47,8 @@ export const getRowSizeClassName = (rowData: RowData): string => {
   return `size-${rowSize}`;
 };
 
+const formatWidth = (width: string | number): string => (isString(width) ? width : `${width}px`);
+
 export const calculatePinnedPosition = (
   columnIndex: number,
   columns: (PrimaryColumn | FixedColumn)[],
@@ -118,6 +120,7 @@ export const getGridTemplateColumns = (
   renderRowActions: boolean,
   isHeader = false,
   columnWidths?: Record<string, number>,
+  isResizable = false,
 ): string => {
   const columns: string[] = [];
 
@@ -138,15 +141,19 @@ export const getGridTemplateColumns = (
 
     if (isPrimaryColumn(column)) {
       const primaryColumn = column as PrimaryColumn;
+
+      if (isResizable && primaryColumn.width) {
+        columns.push(formatWidth(primaryColumn.width));
+        return;
+      }
+
       const minWidth = primaryColumn.width
-        ? isString(primaryColumn.width)
-          ? primaryColumn.width
-          : `${primaryColumn.width}px`
+        ? formatWidth(primaryColumn.width)
         : `${PRIMARY_COLUMN_DEFAULT_WIDTH}px`;
       columns.push(`minmax(${minWidth}, 1fr)`);
     } else {
       const fixedColumn = column as FixedColumn;
-      const width = isString(fixedColumn.width) ? fixedColumn.width : `${fixedColumn.width}px`;
+      const width = formatWidth(fixedColumn.width);
       columns.push(width);
     }
   };


### PR DESCRIPTION
## Changes
**Problem:** When table re-mounts (e.g., on page change with loading state), the first column (primary) width was resetting to `minmax` instead of keeping the saved width from config.

**Solution:** Added `isResizable` parameter to handle column widths differently:

- If `columnWidths[key]` exists (after resize) → use exact `{width}px`
- If `isResizable` && `primaryColumn.width` exists → use exact width from config
- Otherwise → use `minmax(width, 1fr)` (default flexible behavior)

**Changes:**
1. Added `isResizable` parameter to `getGridTemplateColumns`
2. Extracted `formatWidth` helper to module level
3. Updated `table.tsx` to pass `isResizable` flag

This ensures that saved column widths from config are respected after table re-mount, while still allowing flexible `minmax` behavior for columns without explicit width.

## Links
[EPMRPP-110935](https://jiraeu.epam.com/browse/EPMRPP-110935)

## Visuals
**_Before:_**  
https://github.com/user-attachments/assets/f503ab92-c76e-452d-bad3-8f76b4048f15

**_After:_**
https://github.com/user-attachments/assets/b80aeb62-ee98-4384-8d63-f434721bd4a2

  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tables now support resizable columns, allowing users to adjust column widths dynamically.

* **Improvements**
  * Enhanced column width calculation and formatting for improved layout consistency across table configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->