### PR TITLE
EPMRPP-111008 || Fix Dropdown component API for backward copatibility

### DIFF
--- a/src/common/utils/htmlAttributes.ts
+++ b/src/common/utils/htmlAttributes.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Splits object properties into HTML attributes and remaining props.
+ * Transforms camelCase data-* and aria-* attributes to kebab-case format
+ * as required by HTML specification.
+ *
+ * @param attrs - Object containing properties to split
+ * @returns Object with two properties:
+ *   - transformed: data-* and aria-* attributes converted to kebab-case
+ *   - remaining: all other properties unchanged
+ *
+ * @example
+ * const props = { dataTestId: 'test', ariaLabel: 'Label', className: 'container' };
+ * const { transformed, remaining } = splitHtmlAttributes(props);
+ * // transformed: { 'data-test-id': 'test', 'aria-label': 'Label' }
+ * // remaining: { className: 'container' }
+ */
+export const splitHtmlAttributes = (attrs: Record<string, unknown>) => {
+  const transformed: Record<string, unknown> = {};
+  const remaining: Record<string, unknown> = {};
+
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (/^data[A-Z]/.test(key) || /^aria[A-Z]/.test(key)) {
+      const kebabKey = key
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+        .toLowerCase();
+      transformed[kebabKey] = value;
+    } else {
+      remaining[key] = value;
+    }
+  });
+
+  return { transformed, remaining };
+};

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -17,3 +17,4 @@
 export { getFileExtension } from './getFileExtension';
 export { isString } from './isString';
 export { getAlignmentAxisOffset } from './floatingUi';
+export { splitHtmlAttributes } from './htmlAttributes';

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -13,6 +13,7 @@ import {
   KeyboardEvent,
   ChangeEvent,
   FocusEvent,
+  ComponentPropsWithRef,
 } from 'react';
 import { isEmpty } from 'es-toolkit/compat';
 import { createPortal } from 'react-dom';
@@ -47,7 +48,8 @@ import styles from './dropdown.module.scss';
 
 const cx = classNames.bind(styles);
 
-export interface DropdownProps {
+export interface DropdownProps
+  extends Omit<ComponentPropsWithRef<'div'>, 'onChange' | 'onFocus' | 'onBlur' | 'title'> {
   // TODO: make value and options optional
   options: DropdownOptionType[];
   value: DropdownValue | DropdownValue[];
@@ -136,7 +138,22 @@ export const Dropdown: FC<DropdownProps> = ({
   menuPortalRoot,
   isMultiSelectWithTags = false,
   noMatchesMessage = 'No matches found',
+  ...rest
 }): ReactElement => {
+  // Transform camelCase data-* and aria-* attributes to kebab-case
+  const transformedAttributes: Record<string, unknown> = {};
+  const restProps: Record<string, unknown> = {};
+
+  Object.entries(rest).forEach(([key, attrValue]) => {
+    if (key.startsWith('data') || key.startsWith('aria')) {
+      // Convert camelCase to kebab-case (e.g., dataAutomationId -> data-automation-id)
+      const kebabKey = key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+      transformedAttributes[kebabKey] = attrValue;
+    } else {
+      restProps[key] = attrValue;
+    }
+  });
+
   const [opened, setOpened] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
@@ -598,7 +615,13 @@ export const Dropdown: FC<DropdownProps> = ({
       return placeholder;
     }
 
-    return undefined;
+    // Fallback for string values that are not found in options
+    // Only applies when placeholder is not set (empty string is used by default)
+    if (typeof value === 'string' && value.length > 0 && !placeholder) {
+      return value;
+    }
+
+    return placeholder || undefined;
   }, [
     multiSelect,
     value,
@@ -863,7 +886,13 @@ export const Dropdown: FC<DropdownProps> = ({
   void toggleButtonType;
 
   return (
-    <div ref={containerRef} className={cx('container', className)} title={title}>
+    <div
+      ref={containerRef}
+      className={cx('container', className)}
+      title={title}
+      {...restProps}
+      {...transformedAttributes}
+    >
       {label && (
         <FieldLabel
           {...getLabelProps()}

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -26,6 +26,7 @@ import { BaseIconButton } from '@components/baseIconButton';
 import { ClearIcon, DropdownIcon } from '@components/icons';
 import { FieldLabel } from '@components/fieldLabel';
 import { AdaptiveTagList } from '@components/adaptiveTagList';
+import { splitHtmlAttributes } from '@common/utils';
 import { DropdownOption } from './dropdownOption';
 import { DropdownVariant, RenderDropdownOption, DropdownOptionType, DropdownValue } from './types';
 import {
@@ -140,22 +141,7 @@ export const Dropdown: FC<DropdownProps> = ({
   noMatchesMessage = 'No matches found',
   ...rest
 }): ReactElement => {
-  // Transform camelCase data-* and aria-* attributes to kebab-case
-  const transformedAttributes: Record<string, unknown> = {};
-  const restProps: Record<string, unknown> = {};
-
-  Object.entries(rest).forEach(([key, attrValue]) => {
-    if (key.startsWith('data') || key.startsWith('aria')) {
-      // Convert camelCase to kebab-case (e.g., dataAutomationId -> data-automation-id)
-      const kebabKey = key
-        .replace(/([a-z])([A-Z])/g, '$1-$2')
-        .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
-        .toLowerCase();
-      transformedAttributes[kebabKey] = attrValue;
-    } else {
-      restProps[key] = attrValue;
-    }
-  });
+  const { transformed: transformedAttributes, remaining: restProps } = splitHtmlAttributes(rest);
 
   const [opened, setOpened] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -147,7 +147,10 @@ export const Dropdown: FC<DropdownProps> = ({
   Object.entries(rest).forEach(([key, attrValue]) => {
     if (key.startsWith('data') || key.startsWith('aria')) {
       // Convert camelCase to kebab-case (e.g., dataAutomationId -> data-automation-id)
-      const kebabKey = key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+      const kebabKey = key
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+        .toLowerCase();
       transformedAttributes[kebabKey] = attrValue;
     } else {
       restProps[key] = attrValue;


### PR DESCRIPTION
# Dropdown Component: Backward Compatibility and Attribute Transformation

## Summary
Enhanced the Dropdown component to provide better backward compatibility with legacy implementations and automatic attribute transformation for data/aria attributes.

## Changes Made

### 1. ComponentPropsWithRef Type Integration
- Replaced manual props spreading with `ComponentPropsWithRef<'div'>`
- Enables proper forwarding of all valid HTML div attributes
- Improves type safety and IntelliSense support

### 2. Universal Data/Aria Attribute Transformation
- Implemented automatic camelCase → kebab-case transformation for `data-*` and `aria-*` attributes
- Solves React's limitation where camelCase data attributes are not automatically transformed
- Example: `dataAutomationId="dropdown"` → `data-automation-id="dropdown"` in DOM

### 3. String Value Fallback Support
- Added fallback logic to display string values when not found in options
- Only applies when `placeholder` prop is not explicitly set
- Ensures backward compatibility with legacy code that passes string values directly
- Respects placeholder priority: explicit placeholder always takes precedence

**Logic:**
```typescript
// Fallback for string values that are not found in options
// Only applies when placeholder is not set (empty string is used by default)
if (typeof value === 'string' && value.length > 0 && !placeholder) {
  return value;
}
return placeholder || undefined;
```

## Benefits

### Backward Compatibility
- Works with plugins using string values instead of option objects
- No breaking changes for existing implementations
- Graceful degradation when options are not provided

### Developer Experience
- Automatic attribute transformation eliminates manual kebab-case conversion
- Better TypeScript support through ComponentPropsWithRef
- Consistent behavior with legacy Dropdown component

### QA/Testing
- `dataAutomationId` prop now correctly transforms to `data-automation-id` in DOM
- All data-* and aria-* attributes work as expected
- Automation tests can use camelCase props while DOM receives proper kebab-case attributes

## Migration Guide

### No Changes Required
Existing code continues to work without modifications. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdown now accepts and passes through standard HTML attributes (including data/aria) for greater customization and proper kebab-casing.
  * HTML attribute passthrough enables arbitrary attributes on the dropdown container for testing and accessibility.

* **Bug Fixes**
  * Displayed-value logic improved to show raw string values when no placeholder is present and options don't match.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->