### PR TITLE
EPMRPP-110490 || Apply className from inputProps to input in MultipleAutocomplete

### DIFF
--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -333,7 +333,7 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
                         disabled,
                         ...inputProps,
                       })}
-                      className={cx('input', { disabled })}
+                      className={cx('input', { disabled }, inputProps.className)}
                       data-automation-id={dataAutomationId}
                     />
                   </div>


### PR DESCRIPTION
### Description

Add className from inputProps to the CSS classes of the input component in MultipleAutocomplete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where custom CSS classes passed to the multiple autocomplete input were not being properly applied, ensuring external styling preferences are now correctly rendered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->