### PR TITLE
EPMRPP-111025 || Tooltip is blinking when content size changes

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -120,6 +120,7 @@ export const Tooltip: FC<TooltipProps> = ({
         ...styleWidth,
         minWidth,
         zIndex,
+        pointerEvents: 'none',
       }}
       data-automation-id={dataAutomationId}
       className={cx(tooltipClassName)}


### PR DESCRIPTION
## Summary
### Problem
The tooltip content is loaded asynchronously.
When the content arrives, the tooltip’s height changes and `@floating-ui` recalculates its position.

During this repositioning, the floating element (tooltip) temporarily **overlaps the reference element**, so the browser fires a `mouseleave` event on the reference element even though the mouse did not actually move. This causes the tooltip to close and reopen briefly.

### Solution
```css
pointer-events: none;
```
Applied to the floating tooltip element
* The floating element is removed from hit-testing
* It can no longer “steal” hover from the reference element
* Layout changes and position recalculations no longer trigger false `mouseleave` events
* The tooltip can safely resize and reposition without closing

## Links
[EPMRPP-111025](https://jiraeu.epam.com/browse/EPMRPP-111025)

## Visuals
**_Before:_**  

https://github.com/user-attachments/assets/a13ff9e8-2c88-4081-9a3f-ff741572c779

**_After:_**  

https://github.com/user-attachments/assets/be1a1a86-227c-4435-bdae-facb64ded7d4




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip interaction behavior to prevent tooltips from blocking pointer events with underlying page elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->