### PR TITLE
EPMRPP-107737 || Fix the scroll jump on clicking on the checkbox

### DIFF
--- a/src/components/checkbox/checkbox.module.scss
+++ b/src/components/checkbox/checkbox.module.scss
@@ -28,6 +28,7 @@
 }
 
 .checkbox {
+  position: relative;
   display: inline-flex;
   align-items: center;
   padding-left: 24px;


### PR DESCRIPTION
## Summary

**Problem**: 
When clicking a checkbox, the browser automatically scrolls to bring the focused element into view. The checkbox's `<input>` element has `position: absolute; top: 0; left: 0;` in its styles. Since its parent `.checkbox` didn't have `position: relative`, the input's absolute positioning was resolved against a higher-level ancestor. The browser interpreted the input as being "at the top" of that container and scrolled there on focus.

**Solution**: 
Added `position: relative` to the `.checkbox` wrapper. This establishes a new positioning context, so the absolutely positioned input is anchored to its parent. The browser's focus-scroll behavior then keeps the scroll position stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted checkbox component positioning context for improved layout alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->