### PR TITLE
EPMRPP-107737 || Implement ability to render the checkbox column outside of the table

### DIFF
--- a/src/components/table/hooks/index.ts
+++ b/src/components/table/hooks/index.ts
@@ -5,3 +5,4 @@ export { useColumnWidths } from './useColumnWidths';
 export { useColumnResize } from './useColumnResize';
 export { useRightGradientPosition, usePinnedGradientPosition } from './useGradientPosition';
 export type { RightGradientPosition, PinnedGradientPosition } from './useGradientPosition';
+export { useCheckboxRowSync } from './useCheckboxRowSync';

--- a/src/components/table/hooks/useCheckboxRowSync.ts
+++ b/src/components/table/hooks/useCheckboxRowSync.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+
+interface UseCheckboxRowSyncProps {
+  enabled: boolean;
+  rowCount: number;
+}
+
+export const useCheckboxRowSync = ({ enabled, rowCount }: UseCheckboxRowSyncProps) => {
+  const tableRowRefs = useRef<Map<number, HTMLElement>>(new Map());
+  const checkboxRowRefs = useRef<Map<number, HTMLElement>>(new Map());
+
+  const setTableRowRef = useCallback(
+    (index: number) => (el: HTMLElement | null) => {
+      if (el) {
+        tableRowRefs.current.set(index, el);
+      } else {
+        tableRowRefs.current.delete(index);
+      }
+    },
+    [],
+  );
+
+  const setCheckboxRowRef = useCallback(
+    (index: number) => (el: HTMLElement | null) => {
+      if (el) {
+        checkboxRowRefs.current.set(index, el);
+      } else {
+        checkboxRowRefs.current.delete(index);
+      }
+    },
+    [],
+  );
+
+  const syncRowHeight = useCallback((tableRow: HTMLElement, checkboxRow: HTMLElement) => {
+    const newHeight = `${tableRow.offsetHeight}px`;
+    if (checkboxRow.style.height !== newHeight) {
+      checkboxRow.style.height = newHeight;
+    }
+  }, []);
+
+  const syncAllHeights = useCallback(() => {
+    tableRowRefs.current.forEach((tableRow, index) => {
+      const checkboxRow = checkboxRowRefs.current.get(index);
+      if (checkboxRow) {
+        syncRowHeight(tableRow, checkboxRow);
+      }
+    });
+  }, [syncRowHeight]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      requestAnimationFrame(() => {
+        entries.forEach((entry) => {
+          const tableRow = entry.target as HTMLElement;
+          const index = parseInt(tableRow.dataset.rowIndex || '-1', 10);
+          const checkboxRow = checkboxRowRefs.current.get(index);
+
+          if (checkboxRow && index >= 0) {
+            syncRowHeight(tableRow, checkboxRow);
+          }
+        });
+      });
+    });
+
+    tableRowRefs.current.forEach((el) => resizeObserver.observe(el));
+
+    return () => resizeObserver.disconnect();
+  }, [enabled, rowCount, syncRowHeight]);
+
+  useLayoutEffect(() => {
+    if (!enabled) return;
+
+    syncAllHeights();
+  }, [enabled, rowCount, syncAllHeights]);
+
+  return { setTableRowRef, setCheckboxRowRef, syncAllHeights };
+};

--- a/src/components/table/table.module.scss
+++ b/src/components/table/table.module.scss
@@ -507,7 +507,7 @@ $EXPANDABLE_CHECKBOX_Z_INDEX: 10;
 }
 
 /* Checkbox outside styles start */
-.table-outer-wrapper {
+.table-wrapper {
   position: relative;
   display: flex;
   width: calc(100% + $EXPANDABLE_CHECKBOX_COLUMN_WIDTH);

--- a/src/components/table/table.module.scss
+++ b/src/components/table/table.module.scss
@@ -6,6 +6,8 @@ $HEIGHT-LARGE: 80px;
 $PADDING_VERTICAL-SMALL: 12px;
 $PADDING_VERTICAL-DEFAULT: 22px;
 $PADDING_VERTICAL-LARGE: 30px;
+$EXPANDABLE_CHECKBOX_COLUMN_WIDTH: 32px;
+$EXPANDABLE_CHECKBOX_Z_INDEX: 10;
 
 .table {
   width: 100%;
@@ -51,7 +53,7 @@ $PADDING_VERTICAL-LARGE: 30px;
     padding: 0 3px 0 0;
     top: 0;
     left: 0;
-    z-index: 5;
+    z-index: $EXPANDABLE_CHECKBOX_Z_INDEX + 1;
     border-bottom: 1px solid var(--rp-ui-base-e-100);
     flex-shrink: 0;
     box-sizing: border-box;
@@ -109,7 +111,7 @@ $PADDING_VERTICAL-LARGE: 30px;
 
   &.selectable {
     display: grid;
-    grid-template-columns: 32px 1fr;
+    grid-template-columns: $EXPANDABLE_CHECKBOX_COLUMN_WIDTH 1fr;
   }
 
   .row-content-wrapper {
@@ -320,14 +322,15 @@ $PADDING_VERTICAL-LARGE: 30px;
   }
 
   &.checkbox-cell {
-    width: 32px;
+    width: $EXPANDABLE_CHECKBOX_COLUMN_WIDTH;
     padding: 0;
+    margin-left: 8px;
     align-self: center;
     height: 18px;
     cursor: pointer;
     position: sticky;
     left: 0;
-    z-index: 10;
+    z-index: $EXPANDABLE_CHECKBOX_Z_INDEX;
 
     label {
       height: 18px;
@@ -342,13 +345,13 @@ $PADDING_VERTICAL-LARGE: 30px;
 
   &.expand-cell {
     padding: 0;
-    width: 32px;
+    width: $EXPANDABLE_CHECKBOX_COLUMN_WIDTH;
     display: flex;
     align-items: flex-start;
     align-self: stretch;
     position: sticky;
     left: 0;
-    z-index: 10;
+    z-index: $EXPANDABLE_CHECKBOX_Z_INDEX;
     background-color: inherit;
 
     button {
@@ -411,9 +414,9 @@ $PADDING_VERTICAL-LARGE: 30px;
   padding: 0 16px;
   align-self: center;
 
-   &.expand-cell {
+  &.expand-cell {
     align-items: center;
-   }
+  }
 
   .label {
     display: flex;
@@ -502,3 +505,81 @@ $PADDING_VERTICAL-LARGE: 30px;
     }
   }
 }
+
+/* Checkbox outside styles start */
+.table-outer-wrapper {
+  position: relative;
+  display: flex;
+  width: calc(100% + $EXPANDABLE_CHECKBOX_COLUMN_WIDTH);
+  margin-left: -$EXPANDABLE_CHECKBOX_COLUMN_WIDTH;
+  height: 100%;
+  overflow: hidden;
+
+  * {
+    box-sizing: border-box;
+  }
+}
+
+.checkbox-column {
+  width: $EXPANDABLE_CHECKBOX_COLUMN_WIDTH;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: 100%;
+
+  .checkbox-cell {
+    margin-left: 8px;
+  }
+}
+
+.checkbox-header {
+  width: $EXPANDABLE_CHECKBOX_COLUMN_WIDTH;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  .fixed-header & {
+    position: sticky;
+    top: 0;
+    z-index: $EXPANDABLE_CHECKBOX_Z_INDEX + 1;
+  }
+
+  &.pinned-header {
+    position: fixed;
+  }
+
+  label {
+    height: 18px;
+    width: 16px;
+
+    span {
+      background-color: var(--rp-ui-base-bg-000);
+    }
+  }
+}
+
+.checkbox-body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  label {
+    height: 18px;
+    width: 16px;
+
+    span {
+      background-color: var(--rp-ui-base-bg-000);
+    }
+  }
+}
+/* Checkbox outside styles end */

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -1742,3 +1742,82 @@ export const HorizontalScrollWithPinnedHeader: Story = {
     renderRowActions,
   },
 };
+
+/**
+ * Demonstrates resizable columns with horizontal scroll and checkbox outside.
+ */
+export const ResizableColumnsWithCheckboxOutside: Story = {
+  render: (args: TableComponentProps) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [checkedRows, setCheckedRows] = useState<Set<number | string>>(new Set([]));
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [expandedRows, setExpandedRows] = useState<Set<number | string>>(new Set([]));
+
+    return (
+      <div
+        style={{
+          width: '600px',
+          height: '500px',
+          border: '1px solid #ccc',
+          padding: '16px',
+          paddingLeft: '48px',
+        }}
+      >
+        <div style={{ height: 'calc(100% - 16px)', position: 'relative' }}>
+          <Table
+            {...args}
+            data={wideTableData}
+            primaryColumn={wideTablePrimaryColumns}
+            fixedColumns={wideTableFixedColumns}
+            expandedRowIds={[...expandedRows]}
+            selectedRowIds={[...checkedRows]}
+            onToggleRowSelection={(id) => {
+              const newCheckedRows = new Set(checkedRows);
+              if (newCheckedRows.has(id)) {
+                newCheckedRows.delete(id);
+              } else {
+                newCheckedRows.add(id);
+              }
+              setCheckedRows(newCheckedRows);
+            }}
+            onToggleAllRowsSelection={() => {
+              if (checkedRows.size === wideTableData.length) {
+                setCheckedRows(new Set());
+              } else {
+                const allRows = new Set(wideTableData.map((item) => item.id));
+                setCheckedRows(allRows);
+              }
+            }}
+            onToggleRowExpansion={(id) => {
+              const newExpandedRows = new Set(expandedRows);
+              if (newExpandedRows.has(id)) {
+                newExpandedRows.delete(id);
+              } else {
+                newExpandedRows.add(id);
+              }
+              setExpandedRows(newExpandedRows);
+            }}
+            onToggleAllRowsExpansion={() => {
+              if (expandedRows.size === wideTableData.length) {
+                setExpandedRows(new Set());
+              } else {
+                const allRows = new Set(wideTableData.map((item) => item.id));
+                setExpandedRows(allRows);
+              }
+            }}
+          />
+        </div>
+      </div>
+    );
+  },
+  args: {
+    renderRowActions,
+    isResizable: true,
+    isHeaderFixed: true,
+    isHorizontallyScrollable: true,
+    pinnedColumnKeys: ['name', 'email'],
+    selectable: true,
+    isRowsExpandable: true,
+    isCheckboxOutside: true,
+  },
+};

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -56,6 +56,7 @@ export const Table: FC<TableComponentProps> = ({
   fixedColumns,
   renderRowActions,
   className = '',
+  wrapperClassName = '',
   rowClassName = '',
   headerClassName = '',
   bodyClassName = '',
@@ -980,7 +981,7 @@ export const Table: FC<TableComponentProps> = ({
   );
 
   return isCheckboxOutside ? (
-    <div className={cx('table-outer-wrapper', { 'fixed-header': isHeaderFixed }, className)}>
+    <div className={cx('table-wrapper', { 'fixed-header': isHeaderFixed }, wrapperClassName)}>
       {renderCheckboxColumn()}
       {renderTable()}
     </div>

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,4 +1,4 @@
-import { useMemo, FC, useEffect, useRef, useState, useCallback } from 'react';
+import { useMemo, FC, useEffect, useRef, useState, useCallback, useLayoutEffect } from 'react';
 import { Resizable } from 'react-resizable';
 import { isEmpty } from 'es-toolkit/compat';
 import styles from './table.module.scss';
@@ -24,6 +24,7 @@ import {
   useColumnResize,
   useRightGradientPosition,
   usePinnedGradientPosition,
+  useCheckboxRowSync,
 } from './hooks';
 import { ResizeHandle } from './resizeHandle';
 import { GradientOverlay } from './gradientOverlay';
@@ -74,6 +75,7 @@ export const Table: FC<TableComponentProps> = ({
   minColumnWidth = 50,
   maxColumnWidth = 500,
   isSelectAllCheckboxAlwaysVisible = false,
+  isCheckboxOutside = false,
   onChangeSorting = () => {},
   onToggleRowSelection = () => {},
   onToggleAllRowsSelection = () => {},
@@ -126,6 +128,11 @@ export const Table: FC<TableComponentProps> = ({
     onColumnResize,
   });
 
+  const { setTableRowRef, setCheckboxRowRef } = useCheckboxRowSync({
+    enabled: selectable && isCheckboxOutside,
+    rowCount: data.length,
+  });
+
   const wrapWithResizable = (column: PrimaryColumn | FixedColumn, headerCell: JSX.Element) => (
     <Resizable
       key={column.key}
@@ -149,6 +156,8 @@ export const Table: FC<TableComponentProps> = ({
   const tableRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
+  const checkboxColumnRef = useRef<HTMLDivElement>(null);
+  const checkboxHeaderRef = useRef<HTMLDivElement>(null);
   const [isHeaderPinned, setIsHeaderPinned] = useState(false);
 
   const updateLeftBorderAccentStyle = useCallback((element: HTMLElement) => {
@@ -253,6 +262,7 @@ export const Table: FC<TableComponentProps> = ({
     false,
     isResizable ? columnWidths : undefined,
     isResizable,
+    isCheckboxOutside,
   );
 
   const headerGridTemplateColumns = getGridTemplateColumns(
@@ -264,6 +274,7 @@ export const Table: FC<TableComponentProps> = ({
     true,
     isResizable ? columnWidths : undefined,
     isResizable,
+    isCheckboxOutside,
   );
 
   const expandAllButton = (
@@ -282,6 +293,7 @@ export const Table: FC<TableComponentProps> = ({
     const scrollContainer = externalScrollContainerRef.current;
     const table = tableRef.current;
     const header = headerRef.current;
+    const checkboxHeader = checkboxHeaderRef.current;
 
     const updatePinnedState = () => {
       const tableRect = table.getBoundingClientRect();
@@ -307,6 +319,10 @@ export const Table: FC<TableComponentProps> = ({
         header.style.left = `${tableLeft}px`;
         header.style.top = `${topOffset}px`;
         header.style.width = `${tableRect.width}px`;
+
+        if (checkboxHeader && isCheckboxOutside) {
+          checkboxHeader.style.top = `${topOffset}px`;
+        }
       } else {
         const savedScrollLeft = table.scrollLeft;
 
@@ -322,6 +338,11 @@ export const Table: FC<TableComponentProps> = ({
         if (isHorizontallyScrollable) {
           header.style.overflow = '';
           header.style.overflowX = '';
+        }
+
+        if (checkboxHeader && isCheckboxOutside) {
+          checkboxHeader.style.top = '';
+          checkboxHeader.classList.remove(cx('pinned-header'));
         }
 
         if (isHorizontallyScrollable && savedScrollLeft > 0) {
@@ -349,7 +370,7 @@ export const Table: FC<TableComponentProps> = ({
       scrollContainer.removeEventListener('scroll', updatePinnedState);
       window.removeEventListener('resize', updatePinnedState);
     };
-  }, [externalScrollContainerRef, isHorizontallyScrollable]);
+  }, [externalScrollContainerRef, isHorizontallyScrollable, isCheckboxOutside]);
 
   useEffect(() => {
     if (
@@ -364,6 +385,7 @@ export const Table: FC<TableComponentProps> = ({
     const scrollContainer = externalScrollContainerRef.current;
     const table = tableRef.current;
     const header = headerRef.current;
+    const checkboxHeader = checkboxHeaderRef.current;
 
     const updateHeaderPosition = () => {
       const tableRect = table.getBoundingClientRect();
@@ -372,6 +394,10 @@ export const Table: FC<TableComponentProps> = ({
       header.style.left = `${tableRect.left}px`;
       header.style.top = `${containerRect.top}px`;
       header.style.width = `${tableRect.width}px`;
+
+      if (checkboxHeader && isCheckboxOutside) {
+        checkboxHeader.style.top = `${containerRect.top}px`;
+      }
     };
 
     const syncHorizontalScroll = (source: HTMLElement) => {
@@ -418,7 +444,7 @@ export const Table: FC<TableComponentProps> = ({
       scrollContainer.removeEventListener('scroll', handleContainerScroll);
       window.removeEventListener('resize', updateHeaderPosition);
     };
-  }, [isHeaderPinned, externalScrollContainerRef, isHorizontallyScrollable]);
+  }, [isHeaderPinned, externalScrollContainerRef, isHorizontallyScrollable, isCheckboxOutside]);
 
   useEffect(() => {
     if (!tableRef.current || !isHorizontallyScrollable) {
@@ -577,7 +603,93 @@ export const Table: FC<TableComponentProps> = ({
     return () => clearTimeout(timeoutId);
   }, [isRowsExpandable, expandedRowIds, updateLeftBorderAccentStyle]);
 
-  return (
+  useEffect(() => {
+    if (!checkboxColumnRef.current || !tableRef.current || !isCheckboxOutside) {
+      return undefined;
+    }
+
+    const checkboxColumn = checkboxColumnRef.current;
+    const table = tableRef.current;
+
+    const handleTableScroll = () => {
+      requestAnimationFrame(() => {
+        checkboxColumn.scrollTop = table.scrollTop;
+      });
+    };
+
+    table.addEventListener('scroll', handleTableScroll);
+
+    return () => {
+      table.removeEventListener('scroll', handleTableScroll);
+    };
+  }, [data, isCheckboxOutside]);
+
+  useLayoutEffect(() => {
+    if (!tableRef.current || !checkboxColumnRef.current) return;
+
+    const table = tableRef.current;
+    const checkboxColumn = checkboxColumnRef.current;
+
+    const syncHeight = () => {
+      const newHeight = `${table.clientHeight}px`;
+      if (checkboxColumn.style.height !== newHeight) {
+        checkboxColumn.style.height = newHeight;
+      }
+    };
+
+    syncHeight();
+
+    const observer = new ResizeObserver(() => {
+      requestAnimationFrame(syncHeight);
+    });
+    observer.observe(table);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const renderCheckboxColumn = () => (
+    <div className={cx('checkbox-column')} ref={checkboxColumnRef}>
+      <div
+        ref={checkboxHeaderRef}
+        className={cx(
+          'table-header',
+          'checkbox-header',
+          { 'pinned-header': isHeaderPinned },
+          headerClassName,
+        )}
+      >
+        {isSelectAllCheckboxVisible && (
+          <Checkbox
+            value={isAllRowsSelected}
+            partiallyChecked={isAnyRowSelected}
+            onChange={handleSelectAllRows}
+            className={cx('checkbox-cell')}
+          />
+        )}
+      </div>
+      <div className={cx('checkbox-body', bodyClassName)}>
+        {data.map((item, index) => (
+          <div
+            key={item.id}
+            ref={setCheckboxRowRef(index)}
+            className={cx('checkbox-row', 'table-row', getRowSizeClassName(item), rowClassName)}
+            onMouseEnter={() => handleRowMouseEnter(index)}
+            onMouseLeave={handleRowMouseLeave}
+          >
+            {(hasSelectedRows || hoveredRow === index) && (
+              <Checkbox
+                value={selectedRowIds.includes(item.id)}
+                onChange={() => handleSingleRowSelection(item.id)}
+                className={cx('checkbox-cell')}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const renderTable = () => (
     <div
       ref={tableRef}
       className={cx(
@@ -604,7 +716,7 @@ export const Table: FC<TableComponentProps> = ({
         )}
         style={{ gridTemplateColumns: headerGridTemplateColumns }}
       >
-        {selectable && (
+        {selectable && !isCheckboxOutside && (
           <div
             className={cx('table-header-cell', 'checkbox-cell')}
             data-base-left={isRowsExpandable ? EXPANDABLE_CHECKBOX_COLUMN_WIDTH : 0}
@@ -658,6 +770,7 @@ export const Table: FC<TableComponentProps> = ({
                 columnWidthsRef,
                 isRowsExpandable,
                 selectable,
+                isCheckboxOutside,
               )}
             >
               <div
@@ -693,6 +806,7 @@ export const Table: FC<TableComponentProps> = ({
                 columnWidthsRef,
                 isRowsExpandable,
                 selectable,
+                isCheckboxOutside,
               )}
             >
               <div
@@ -729,13 +843,14 @@ export const Table: FC<TableComponentProps> = ({
           <div
             key={item.id}
             data-row-index={index}
+            ref={setTableRowRef(index)}
             className={cx('table-row', getRowSizeClassName(item), rowClassName, {
-              selectable: selectable,
+              selectable: selectable && !isCheckboxOutside,
             })}
             onMouseEnter={() => handleRowMouseEnter(index)}
             onMouseLeave={handleRowMouseLeave}
           >
-            {selectable && (
+            {selectable && !isCheckboxOutside && (
               <div
                 className={cx('table-cell', 'checkbox-cell')}
                 data-base-left={isRowsExpandable ? EXPANDABLE_CHECKBOX_COLUMN_WIDTH : 0}
@@ -794,6 +909,7 @@ export const Table: FC<TableComponentProps> = ({
                         columnWidthsRef,
                         isRowsExpandable,
                         selectable,
+                        isCheckboxOutside,
                       )}
                     >
                       {item[column.key].component || item[column.key].content || item[column.key]}
@@ -820,6 +936,7 @@ export const Table: FC<TableComponentProps> = ({
                         columnWidthsRef,
                         isRowsExpandable,
                         selectable,
+                        isCheckboxOutside,
                       )}
                     >
                       {item[column.key].component || item[column.key].content || item[column.key]}
@@ -860,5 +977,14 @@ export const Table: FC<TableComponentProps> = ({
         </>
       )}
     </div>
+  );
+
+  return isCheckboxOutside ? (
+    <div className={cx('table-outer-wrapper', { 'fixed-header': isHeaderFixed }, className)}>
+      {renderCheckboxColumn()}
+      {renderTable()}
+    </div>
+  ) : (
+    renderTable()
   );
 };

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -46,6 +46,7 @@ export interface TableComponentProps {
   selectable?: boolean;
   isCheckboxOutside?: boolean;
   className?: string;
+  wrapperClassName?: string;
   headerClassName?: string;
   bodyClassName?: string;
   rowClassName?: string;

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -44,6 +44,7 @@ export interface TableComponentProps {
   fixedColumns: FixedColumn[];
   renderRowActions?: (metaData?: MetaData) => ReactNode;
   selectable?: boolean;
+  isCheckboxOutside?: boolean;
   className?: string;
   headerClassName?: string;
   bodyClassName?: string;

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -55,6 +55,7 @@ export const calculatePinnedPosition = (
   columnWidthsRef: MutableRefObject<Map<string, number>>,
   isRowsExpandable: boolean,
   selectable: boolean,
+  isCheckboxOutside = false,
 ): number => {
   let position = 0;
 
@@ -62,7 +63,7 @@ export const calculatePinnedPosition = (
     position += EXPANDABLE_CHECKBOX_COLUMN_WIDTH;
   }
 
-  if (selectable) {
+  if (selectable && !isCheckboxOutside) {
     position += EXPANDABLE_CHECKBOX_COLUMN_WIDTH;
   }
 
@@ -90,6 +91,7 @@ export const getCellStyle = (
   columnWidthsRef: MutableRefObject<Map<string, number>>,
   isRowsExpandable: boolean,
   selectable: boolean,
+  isCheckboxOutside = false,
 ): CSSProperties => {
   const baseStyle: CSSProperties = {};
 
@@ -105,6 +107,7 @@ export const getCellStyle = (
       columnWidthsRef,
       isRowsExpandable,
       selectable,
+      isCheckboxOutside,
     );
     baseStyle.left = `${leftPosition}px`;
   }
@@ -121,6 +124,7 @@ export const getGridTemplateColumns = (
   isHeader = false,
   columnWidths?: Record<string, number>,
   isResizable = false,
+  isCheckboxOutside = false,
 ): string => {
   const columns: string[] = [];
 
@@ -128,7 +132,7 @@ export const getGridTemplateColumns = (
     columns.push(`${EXPANDABLE_CHECKBOX_COLUMN_WIDTH}px`);
   }
 
-  if (isHeader && selectable) {
+  if (isHeader && selectable && !isCheckboxOutside) {
     columns.push(`${EXPANDABLE_CHECKBOX_COLUMN_WIDTH}px`);
   }
 


### PR DESCRIPTION
## Summary
The prop `isCheckboxOutside` allows rendering the selection checkbox column outside of the table grid, positioned to the left of the table. This allows the checkbox column to remain fixed while the table content scrolls horizontally and **does not consume table space**.

## Links
[EPMRPP-107737](https://jiraeu.epam.com/browse/EPMRPP-107737)

## Visuals
https://github.com/user-attachments/assets/6c4b0334-1831-4d13-a285-7d7a007b775b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables can render row-selection checkboxes in a separate column outside the main table, with automatic height synchronization, coordinated vertical scrolling, and compatibility with resizable columns and horizontal scrolling. Added a wrapper option for composing the outside-checkbox layout.
* **Style**
  * Introduced configurable sizing and z-index variables to align the external checkbox column with table layout.
* **Documentation**
  * Added a Storybook example demonstrating the outside-checkbox, resizable columns, and horizontal scroll.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->