### PR TITLE
EPMRPP-111074 || Re-render table when column widths changed via props

### DIFF
--- a/src/components/table/hooks/useColumnResize.ts
+++ b/src/components/table/hooks/useColumnResize.ts
@@ -43,12 +43,15 @@ export const useColumnResize = ({
   useEffect(() => {
     if (initialColumnWidths) {
       const constrainedWidths: Record<string, number> = {};
-      Object.entries(initialColumnWidths).forEach(([key, width]) => {
-        constrainedWidths[key] = Math.min(maxWidth, Math.max(minWidth, width));
+      Object.entries(initialColumnWidths).forEach(([columnKey, width]) => {
+        const column = columns.find((col) => col.key === columnKey);
+        const colMinWidth = column?.minWidth ?? minWidth;
+        const colMaxWidth = column?.maxWidth ?? maxWidth;
+        constrainedWidths[columnKey] = Math.min(colMaxWidth, Math.max(colMinWidth, width));
       });
       setColumnWidths(constrainedWidths);
     }
-  }, [initialColumnWidths, minWidth, maxWidth]);
+  }, [initialColumnWidths, columns, minWidth, maxWidth]);
 
   const handleResizeStart = useCallback(() => {
     if (!enabled || Object.keys(columnWidths).length > 0 || !columnWidthsRef) return;

--- a/src/components/table/hooks/useColumnResize.ts
+++ b/src/components/table/hooks/useColumnResize.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, MutableRefObject, useEffect } from 'react';
+import { useState, useCallback, MutableRefObject, useEffect, useRef } from 'react';
 import { ResizeCallbackData } from 'react-resizable';
 import { PrimaryColumn, FixedColumn } from '../types';
 
@@ -29,6 +29,12 @@ export const useColumnResize = ({
   initialColumnWidths,
 }: UseColumnResizeProps): UseColumnResizeReturn => {
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+  const columnsRef = useRef(columns);
+  const prevInitialColumnWidthsRef = useRef<Record<string, number> | undefined>(undefined);
+
+  useEffect(() => {
+    columnsRef.current = columns;
+  }, [columns]);
 
   const getColumnLimits = useCallback(
     (columnKey: string) => {
@@ -42,16 +48,20 @@ export const useColumnResize = ({
   );
   useEffect(() => {
     if (initialColumnWidths) {
-      const constrainedWidths: Record<string, number> = {};
-      Object.entries(initialColumnWidths).forEach(([columnKey, width]) => {
-        const column = columns.find((col) => col.key === columnKey);
-        const colMinWidth = column?.minWidth ?? minWidth;
-        const colMaxWidth = column?.maxWidth ?? maxWidth;
-        constrainedWidths[columnKey] = Math.min(colMaxWidth, Math.max(colMinWidth, width));
-      });
-      setColumnWidths(constrainedWidths);
+      const hasChanged = prevInitialColumnWidthsRef.current !== initialColumnWidths;
+      if (hasChanged) {
+        const constrainedWidths: Record<string, number> = {};
+        Object.entries(initialColumnWidths).forEach(([columnKey, width]) => {
+          const column = columnsRef.current.find((col) => col.key === columnKey);
+          const colMinWidth = column?.minWidth ?? minWidth;
+          const colMaxWidth = column?.maxWidth ?? maxWidth;
+          constrainedWidths[columnKey] = Math.min(colMaxWidth, Math.max(colMinWidth, width));
+        });
+        setColumnWidths(constrainedWidths);
+        prevInitialColumnWidthsRef.current = initialColumnWidths;
+      }
     }
-  }, [initialColumnWidths, columns, minWidth, maxWidth]);
+  }, [initialColumnWidths, minWidth, maxWidth]);
 
   const handleResizeStart = useCallback(() => {
     if (!enabled || Object.keys(columnWidths).length > 0 || !columnWidthsRef) return;

--- a/src/components/table/hooks/useColumnResize.ts
+++ b/src/components/table/hooks/useColumnResize.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, MutableRefObject } from 'react';
+import { useState, useCallback, MutableRefObject, useEffect } from 'react';
 import { ResizeCallbackData } from 'react-resizable';
 import { PrimaryColumn, FixedColumn } from '../types';
 
@@ -9,6 +9,7 @@ interface UseColumnResizeProps {
   columns?: (PrimaryColumn | FixedColumn)[];
   columnWidthsRef?: MutableRefObject<Map<string, number>>;
   onColumnResize?: (columnKey: string, width: number) => void;
+  initialColumnWidths?: Record<string, number>;
 }
 
 interface UseColumnResizeReturn {
@@ -25,6 +26,7 @@ export const useColumnResize = ({
   columns = [],
   columnWidthsRef,
   onColumnResize,
+  initialColumnWidths,
 }: UseColumnResizeProps): UseColumnResizeReturn => {
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
 
@@ -38,6 +40,15 @@ export const useColumnResize = ({
     },
     [columns, minWidth, maxWidth],
   );
+  useEffect(() => {
+    if (initialColumnWidths) {
+      const constrainedWidths: Record<string, number> = {};
+      Object.entries(initialColumnWidths).forEach(([key, width]) => {
+        constrainedWidths[key] = Math.min(maxWidth, Math.max(minWidth, width));
+      });
+      setColumnWidths(constrainedWidths);
+    }
+  }, [initialColumnWidths, minWidth, maxWidth]);
 
   const handleResizeStart = useCallback(() => {
     if (!enabled || Object.keys(columnWidths).length > 0 || !columnWidthsRef) return;

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -117,21 +117,17 @@ export const Table: FC<TableComponentProps> = ({
   const columnWidthsFromProps = useMemo(() => {
     const widths: Record<string, number> = {};
 
-    if (primaryColumns && Array.isArray(primaryColumns)) {
-      primaryColumns.forEach((col) => {
-        if ('width' in col && typeof col.width === 'number') {
-          widths[col.key] = col.width;
-        }
-      });
-    }
+    primaryColumns.forEach((col) => {
+      if ('width' in col && typeof col.width === 'number') {
+        widths[col.key] = col.width;
+      }
+    });
 
-    if (fixedColumns && Array.isArray(fixedColumns)) {
-      fixedColumns.forEach((col) => {
-        if ('width' in col && typeof col.width === 'number') {
-          widths[col.key] = col.width;
-        }
-      });
-    }
+    fixedColumns.forEach((col) => {
+      if ('width' in col && typeof col.width === 'number') {
+        widths[col.key] = col.width;
+      }
+    });
 
     return Object.keys(widths).length > 0 ? widths : undefined;
   }, [primaryColumns, fixedColumns]);

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -143,11 +143,16 @@ export const Table: FC<TableComponentProps> = ({
     onToggleRowExpansion,
   });
 
+  const allTableColumns = useMemo(
+    () => [...pinnedColumns, ...scrollableColumns],
+    [pinnedColumns, scrollableColumns],
+  );
+
   const { columnWidths, handleResize, handleResizeStop, handleResizeStart } = useColumnResize({
     enabled: isResizable,
     minWidth: minColumnWidth,
     maxWidth: maxColumnWidth,
-    columns: [...pinnedColumns, ...scrollableColumns],
+    columns: allTableColumns,
     columnWidthsRef,
     onColumnResize,
     initialColumnWidths: columnWidthsFromProps,

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -114,6 +114,28 @@ export const Table: FC<TableComponentProps> = ({
 
   const { columnWidthsRef, setCellRef } = useColumnWidths();
 
+  const columnWidthsFromProps = useMemo(() => {
+    const widths: Record<string, number> = {};
+
+    if (primaryColumns && Array.isArray(primaryColumns)) {
+      primaryColumns.forEach((col) => {
+        if ('width' in col && typeof col.width === 'number') {
+          widths[col.key] = col.width;
+        }
+      });
+    }
+
+    if (fixedColumns && Array.isArray(fixedColumns)) {
+      fixedColumns.forEach((col) => {
+        if ('width' in col && typeof col.width === 'number') {
+          widths[col.key] = col.width;
+        }
+      });
+    }
+
+    return Object.keys(widths).length > 0 ? widths : undefined;
+  }, [primaryColumns, fixedColumns]);
+
   const { handleToggleRowExpansion, isCellExpanded } = useTableExpansion({
     primaryColumns,
     fixedColumns,
@@ -128,6 +150,7 @@ export const Table: FC<TableComponentProps> = ({
     columns: [...pinnedColumns, ...scrollableColumns],
     columnWidthsRef,
     onColumnResize,
+    initialColumnWidths: columnWidthsFromProps,
   });
 
   const { setTableRowRef, setCheckboxRowRef } = useCheckboxRowSync({


### PR DESCRIPTION
# PR: Fix Table Column Widths Synchronization

## Overview
Fixed an issue where the Table component failed to re-render when column widths changed via props.

## Problem Statement

### Column Width Changes Not Reflected in Table
When column widths were updated programmatically (e.g., after resetting to default widths), the Table component did not re-render with the new widths. The table would only update after a full page reload or data refresh.

**Root Cause:** The `useColumnResize` hook maintained local state for column widths but never synchronized this state with incoming prop changes. When `fixedColumns` props were updated with new width values, the hook's internal `columnWidths` state remained unchanged.

The code in PR fixes this issue.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables can be initialized with explicit column widths; numeric width values in column configurations are applied as starting widths and remain user-resizable.
  * Provided initial widths are clamped to per-column or global min/max bounds when applied.
  * Initial widths may be derived from visible/pinned columns and are applied only when resizing is enabled; default behavior is unchanged unless initial widths are supplied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->