### PR TITLE
EPMRPP-111026 || Fix wrong border for focused Dropdown

### DIFF
--- a/src/components/dropdown/dropdown.module.scss
+++ b/src/components/dropdown/dropdown.module.scss
@@ -93,7 +93,7 @@ $Z-INDEX-POPUP: 10;
   &:active,
   &:focus-visible {
     border-color: var(--rp-ui-color-primary-focused);
-    box-shadow: 0 0 0 1px var(--rp-ui-color-primary-focused);
+    box-shadow: inset 0 0 0 1px var(--rp-ui-color-primary-focused);
     outline: none;
 
     @include arrow-color(var(--rp-ui-color-field-hover-2));


### PR DESCRIPTION
## Description

Fixed wrong border for focused Dropdown component

## Visuals

<img width="688" height="866" alt="image" src="https://github.com/user-attachments/assets/0e9f0819-09ba-4e82-a181-12bd7ab37f47" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the dropdown component's focus state styling to use an inset shadow effect instead of an outset shadow, enhancing the visual feedback during interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->