### PR TITLE
EPMRPP-111488 || Show separator for last resizable column

### DIFF
--- a/src/components/table/table.module.scss
+++ b/src/components/table/table.module.scss
@@ -476,7 +476,7 @@ $EXPANDABLE_CHECKBOX_Z_INDEX: 10;
     }
   }
 
-  &.resizable:not(:last-child)::after {
+  &.resizable::after {
     content: '';
     position: absolute;
     top: 50%;


### PR DESCRIPTION
## Changes
1. Showed the separator for the last resizable column

## Links
[EPMRPP-111488](https://jiraeu.epam.com/browse/EPMRPP-111488)

## Visuals
_**Before:**_  
<img width="1919" height="668" alt="Screenshot 2026-01-20 140957" src="https://github.com/user-attachments/assets/90ab41cb-f9e6-4f8d-88a6-9747fa47162d" />

_**After:**_  
<img width="1919" height="678" alt="Screenshot 2026-01-20 141740" src="https://github.com/user-attachments/assets/c5a6838a-93fe-4216-8f7a-97a8d48dc2a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table column dividers to display consistently across all resizable column headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->