### PR TITLE
EPMRPP-109801 || Add onCancel callback for the BulkPanel action

### DIFF
--- a/src/components/bulkPanel/bulkPanel.tsx
+++ b/src/components/bulkPanel/bulkPanel.tsx
@@ -106,9 +106,11 @@ export const BulkPanel = ({
   );
 
   const handleCancel = useCallback(() => {
-    currentAction?.onCancel?.();
+    const onCancel = currentAction?.onCancel;
+
     setCurrentAction(null);
     setIsExpanded(false);
+    onCancel?.();
   }, [currentAction]);
 
   const handleProceed = useCallback(() => {

--- a/src/components/bulkPanel/bulkPanel.tsx
+++ b/src/components/bulkPanel/bulkPanel.tsx
@@ -106,9 +106,10 @@ export const BulkPanel = ({
   );
 
   const handleCancel = useCallback(() => {
+    currentAction?.onCancel?.();
     setCurrentAction(null);
     setIsExpanded(false);
-  }, []);
+  }, [currentAction]);
 
   const handleProceed = useCallback(() => {
     currentAction?.onProceed(eligibleItems);

--- a/src/components/bulkPanel/types.ts
+++ b/src/components/bulkPanel/types.ts
@@ -23,6 +23,7 @@ export interface BulkPanelAction {
    * @param direct - true if all items were eligible and proceed was called directly, false if called via Proceed button
    */
   onProceed: (eligibleItems: BulkPanelItem[], direct?: boolean) => void;
+  onCancel?: () => void;
 }
 
 export interface BulkPanelCaptions {


### PR DESCRIPTION
## Changes
1. Added `onCancel` callback for the BulkPanel action (can be needed for user analytics tracking)

## Links
[EPMRPP-109801](https://jiraeu.epam.com/browse/EPMRPP-109801)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Bulk panel cancellation now triggers action-specific cancellation callbacks, ensuring proper cleanup and state reset when an action is cancelled.

* **Bug Fixes**
  * Fixed case where cancelling an in-progress bulk action could leave stale state; cancellations now reliably collapse the panel and run any provided cleanup logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->