### PR TITLE
EPMRPP-110676 || DatePicker. Single field for range

### DIFF
--- a/src/components/datePicker/datePicker.module.scss
+++ b/src/components/datePicker/datePicker.module.scss
@@ -56,7 +56,7 @@ $POPOVER_Z_INDEX: 10;
   .react-datepicker__day {
     cursor: pointer;
 
-    &.react-datepicker__day--in-selecting-range {
+    &--in-selecting-range {
       &:not(.react-datepicker__day--selecting-range-end, .react-datepicker__day--selecting-range-start, .react-datepicker__day--range-start, .react-datepicker__day--range-end) {
         background-color: var(--rp-ui-base-bg-200);
         height: 32px;
@@ -65,13 +65,29 @@ $POPOVER_Z_INDEX: 10;
       }
     }
 
-    &.react-datepicker__day--selected {
+    &--selected {
       position: relative;
-      border-radius: 50%;
-      background-color: var(--rp-ui-base-topaz);
-      font-family: var(--rp-ui-base-font-family);
-      font-weight: var(--rp-ui-base-fw-bold);
+      @include setHoverState(var(--rp-ui-base-topaz));
       color: var(--rp-ui-base-bg-000);
+    }
+
+    &--outside-month {
+      &:not(.react-datepicker__day--range-start, .react-datepicker__day--range-end, .react-datepicker__day--selecting-range-start, .react-datepicker__day--selecting-range-end, .react-datepicker__day--selected) {
+        color: var(--rp-ui-color-text-secondary);
+      }
+    }
+
+    &--today {
+      font-weight: var(--rp-ui-base-fw-bold);
+
+      &:not(.react-datepicker__day--in-selecting-range, .react-datepicker__day--in-range, .react-datepicker__day--selected, .react-datepicker__day--selecting-range-end, .react-datepicker__day--selecting-range-start) {
+        border-radius: 4px;
+        background-color: var(--rp-ui-base-topaz-100);
+      }
+
+      &:not(.react-datepicker__day--range-start, .react-datepicker__day--range-end, .react-datepicker__day--selecting-range-start, .react-datepicker__day--selected) {
+        color: var(--rp-ui-base-topaz);
+      }
     }
   }
 
@@ -109,12 +125,11 @@ $POPOVER_Z_INDEX: 10;
   }
 }
 
-@mixin setHoverState($backgroundColor, $textColor: inherit) {
-  border-radius: 50%;
+@mixin setHoverState($backgroundColor) {
+  border-radius: 4px;
   border: 1px solid var(--rp-ui-base-topaz);
   background-color: $backgroundColor;
   line-height: 38px;
-  color: $textColor;
 }
 
 @mixin removeOutline {
@@ -126,32 +141,6 @@ $POPOVER_Z_INDEX: 10;
 @mixin verticalAlign($height) {
   height: $height;
   line-height: $height;
-}
-
-@mixin drawBeforePseudoElement {
-  position: absolute;
-  content: '';
-  height: 32px;
-  background-color: var(--rp-ui-base-bg-200);
-  width: 16px;
-  top: 0;
-  left: -9px;
-  z-index: 1;
-}
-
-@mixin drawAfterPseudoElement($displayValue, $borderWidth) {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 40px;
-  height: 40px;
-  border: $borderWidth solid var(--rp-ui-base-topaz);
-  border-radius: 50%;
-  display: $displayValue;
-  z-index: $DAY_OF_THE_WEEK_HOVERED_Z_INDEX;
-  box-sizing: border-box;
 }
 
 :global {
@@ -181,72 +170,42 @@ $POPOVER_Z_INDEX: 10;
     @include removeOutline;
   }
 
-  .date {
+  .date.date {
     background-color: transparent;
     border-radius: unset;
     color: inherit;
     text-align: center;
-  }
 
-  .current-date,
-  .current-date:hover {
-    position: relative;
-    z-index: $DAY_OF_THE_WEEK_Z_INDEX;
-    font-family: var(--rp-ui-base-font-family);
-    font-weight: var(--rp-ui-base-fw-bold);
-    @include setHoverState(var(--rp-ui-base-topaz), var(--rp-ui-base-bg-000));
+    &.current-date,
+    &.current-date:hover,
+    &.end-date,
+    &.end-date:hover {
+      position: relative;
+      z-index: $DAY_OF_THE_WEEK_Z_INDEX;
+      font-weight: var(--rp-ui-base-fw-bold);
+      @include setHoverState(var(--rp-ui-base-topaz));
+      color: var(--rp-ui-base-bg-000);
+    }
   }
 
   .date:hover:not(.current-date):not(.selected-range):not(.end-date) {
     @include setHoverState(transparent);
   }
 
-  .end-date,
-  .end-date:hover {
-    position: relative;
-    border-radius: 50%;
-    background-color: var(--rp-ui-base-topaz);
-    font-family: var(--rp-ui-base-font-family);
-    font-weight: var(--rp-ui-base-fw-bold);
-    color: var(--rp-ui-base-bg-000);
-  }
-
-  .end-date::after {
-    @include drawAfterPseudoElement(block, 10px);
-  }
-
-  .end-date::before {
-    @include drawBeforePseudoElement;
-    top: 4px;
-  }
-
-  .selected-range {
+  .date.selected-range {
     background-color: var(--rp-ui-base-bg-200);
-    border-radius: 8px;
     @include verticalAlign(32px);
     position: relative;
     &:hover {
-      @include verticalAlign(40px);
-      border-radius: 50%;
-      background: var(--rp-ui-base-bg-200);
-      &::after {
-        display: block;
-      }
-      &:not(:first-child)::before {
-        top: 4px;
-      }
+      border-radius: 4px;
+      border: 1px solid var(--rp-ui-base-topaz);
+      background-color: var(--rp-ui-base-bg-200);
+      line-height: 38px;
+      height: 40px;
     }
   }
 
-  .selected-range::after {
-    @include drawAfterPseudoElement(none, 1px);
-  }
-
-  .selected-range:not(:first-child)::before {
-    @include drawBeforePseudoElement;
-  }
-
-  .disabled {
+  .date.disabled {
     color: var(--rp-ui-base-e-400);
     background-color: transparent;
     @include removeOutline;
@@ -261,4 +220,8 @@ $POPOVER_Z_INDEX: 10;
   min-width: 138px;
   background: url('/src/components/icons/svg/calendar.svg') no-repeat right 12px center;
   background-size: 16px 16px;
+}
+
+.input-range {
+  min-width: 220px;
 }

--- a/src/components/datePicker/datePicker.stories.tsx
+++ b/src/components/datePicker/datePicker.stories.tsx
@@ -48,18 +48,6 @@ const meta: Meta<typeof DatePicker> = {
       description: 'Specifies whether the calendar should have a fixed height.',
       table: { type: { summary: 'boolean' } },
     },
-    startDate: {
-      control: 'date',
-      description:
-        'The start date of the date range. Used when selects="start" or for range selection.',
-      table: { type: { summary: 'Date | undefined' } },
-    },
-    endDate: {
-      control: 'date',
-      description:
-        'The end date of the date range. Used when selects="end" or for range selection.',
-      table: { type: { summary: 'Date | undefined' } },
-    },
     customClassName: {
       control: 'text',
       description: 'Custom CSS class name to apply to the date picker header.',
@@ -102,17 +90,17 @@ const meta: Meta<typeof DatePicker> = {
       description: 'Format string for displaying the date (e.g., "MM-dd-yyyy", "dd/MM/yyyy").',
       table: { type: { summary: 'string' } },
     },
-    selects: {
-      control: 'select',
-      options: ['start', 'end', 'none'],
-      description:
-        'Specifies the selection mode: "start" for start date, "end" for end date, "none" for single date selection.',
-      table: { type: { summary: "'start' | 'end' | 'none'" } },
-    },
     value: {
       control: 'date',
-      description: 'The currently selected date value.',
-      table: { type: { summary: 'Date | null' } },
+      description:
+        'The currently selected date value (Date for single mode, [Date | null, Date | null] tuple for range mode).',
+      table: { type: { summary: 'Date | null | [Date | null, Date | null]' } },
+    },
+    selectsRange: {
+      control: 'boolean',
+      description:
+        'Enables range selection mode. When true, allows selecting a date range in a single field.',
+      table: { type: { summary: 'boolean' } },
     },
   },
   args: {
@@ -122,14 +110,12 @@ const meta: Meta<typeof DatePicker> = {
     language: 'en',
     placeholder: 'MM-DD-YYYY',
     dateFormat: 'MM-dd-yyyy',
-    selects: 'start',
     value: null,
-    startDate: undefined,
-    endDate: undefined,
     customClassName: '',
     popperClassName: '',
     calendarClassName: '',
     yearsOptions: [],
+    selectsRange: false,
   },
 };
 
@@ -138,7 +124,7 @@ export default meta;
 type Story = StoryObj<typeof DatePicker>;
 
 export const Default: Story = {
-  render: (args) => {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(null);
     return (
@@ -151,7 +137,7 @@ export const Default: Story = {
         }}
       >
         <div>Default DatePicker:</div>
-        <DatePicker {...args} value={date} onChange={setDate} />
+        <DatePicker value={date} onChange={setDate} />
         {date && (
           <div style={{ fontSize: '12px', color: '#666' }}>
             Selected: {date.toLocaleDateString()}
@@ -163,7 +149,7 @@ export const Default: Story = {
 };
 
 export const Single: Story = {
-  render: (args) => {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(null);
     return (
@@ -176,7 +162,7 @@ export const Single: Story = {
         }}
       >
         <div>Single DatePicker:</div>
-        <DatePicker {...args} value={date} onChange={setDate} selects="none" />
+        <DatePicker value={date} onChange={setDate} />
         {date && (
           <div style={{ fontSize: '12px', color: '#666' }}>
             Selected: {date.toLocaleDateString()}
@@ -187,52 +173,27 @@ export const Single: Story = {
   },
 };
 
-export const Range: Story = {
-  render: (args) => {
+export const RangeSingleField: Story = {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [startDate, setStartDate] = useState<Date | null>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [endDate, setEndDate] = useState<Date | null>(null);
+    const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([null, null]);
+    const [startDate, endDate] = dateRange;
+
     return (
-      <div style={{ padding: '200px', display: 'flex', flexDirection: 'column', gap: '20px' }}>
-        <div>Range DatePicker:</div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-          <div>
-            <div style={{ marginBottom: '5px', fontSize: '12px' }}>Start Date:</div>
-            <DatePicker
-              {...args}
-              value={startDate}
-              startDate={startDate || undefined}
-              endDate={endDate || undefined}
-              onChange={setStartDate}
-              selects="start"
-            />
-          </div>
-          <div>
-            <div style={{ marginBottom: '5px', fontSize: '12px' }}>End Date:</div>
-            <DatePicker
-              {...args}
-              value={endDate}
-              startDate={startDate || undefined}
-              endDate={endDate || undefined}
-              onChange={setEndDate}
-              selects="end"
-            />
-          </div>
+      <div style={{ padding: '200px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        <div>Range DatePicker (Single Field):</div>
+        <DatePicker selectsRange value={dateRange} onChange={(dates) => setDateRange(dates)} />
+        <div style={{ marginTop: '10px', fontSize: '12px', color: '#666' }}>
+          <div>Start: {startDate?.toLocaleDateString() ?? 'Not selected'}</div>
+          <div>End: {endDate?.toLocaleDateString() ?? 'Not selected'}</div>
         </div>
-        {(startDate || endDate) && (
-          <div style={{ fontSize: '12px', color: '#666' }}>
-            Range: {startDate?.toLocaleDateString() || '...'} -{' '}
-            {endDate?.toLocaleDateString() || '...'}
-          </div>
-        )}
       </div>
     );
   },
 };
 
 export const WithLocale: Story = {
-  render: (args) => {
+  render: () => {
     registerDatePickerLocale('ru', ru);
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(null);
@@ -246,7 +207,7 @@ export const WithLocale: Story = {
         }}
       >
         <div>DatePicker with Russian locale:</div>
-        <DatePicker {...args} language="ru" value={date} onChange={setDate} />
+        <DatePicker language="ru" value={date} onChange={setDate} />
         {date && (
           <div style={{ fontSize: '12px', color: '#666' }}>
             Selected: {date.toLocaleDateString('ru-RU')}
@@ -258,10 +219,7 @@ export const WithLocale: Story = {
 };
 
 export const Disabled: Story = {
-  args: {
-    disabled: true,
-  },
-  render: (args) => {
+  render: () => {
     return (
       <div
         style={{
@@ -272,14 +230,14 @@ export const Disabled: Story = {
         }}
       >
         <div>Disabled DatePicker:</div>
-        <DatePicker {...args} />
+        <DatePicker disabled />
       </div>
     );
   },
 };
 
 export const WithCustomDateFormat: Story = {
-  render: (args) => {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(null);
     return (
@@ -293,7 +251,6 @@ export const WithCustomDateFormat: Story = {
       >
         <div>DatePicker with custom format (dd/MM/yyyy):</div>
         <DatePicker
-          {...args}
           dateFormat="dd/MM/yyyy"
           placeholder="DD/MM/YYYY"
           value={date}
@@ -310,7 +267,7 @@ export const WithCustomDateFormat: Story = {
 };
 
 export const WithCustomYears: Story = {
-  render: (args) => {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(new Date(2020, 0, 1));
     // Generate years from 2020 to 2030 (inclusive)
@@ -325,7 +282,7 @@ export const WithCustomYears: Story = {
         }}
       >
         <div>DatePicker with custom years range (2020-2030):</div>
-        <DatePicker {...args} yearsOptions={customYears} value={date} onChange={setDate} />
+        <DatePicker yearsOptions={customYears} value={date} onChange={setDate} />
         {date && (
           <div style={{ fontSize: '12px', color: '#666' }}>
             Selected: {date.toLocaleDateString()}
@@ -337,7 +294,7 @@ export const WithCustomYears: Story = {
 };
 
 export const WithHeaderNodes: Story = {
-  render: (args) => {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(null);
     return (
@@ -351,7 +308,6 @@ export const WithHeaderNodes: Story = {
       >
         <div>DatePicker with custom header nodes:</div>
         <DatePicker
-          {...args}
           headerNodes={
             <div style={{ padding: '10px', backgroundColor: '#f0f0f0', borderRadius: '4px' }}>
               Custom Header
@@ -371,7 +327,7 @@ export const WithHeaderNodes: Story = {
 };
 
 export const ShouldNotCloseOnSelect: Story = {
-  render: (args) => {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(null);
     return (
@@ -384,7 +340,7 @@ export const ShouldNotCloseOnSelect: Story = {
         }}
       >
         <div>DatePicker that stays open after selection:</div>
-        <DatePicker {...args} shouldCloseOnSelect={false} value={date} onChange={setDate} />
+        <DatePicker shouldCloseOnSelect={false} value={date} onChange={setDate} />
         {date && (
           <div style={{ fontSize: '12px', color: '#666' }}>
             Selected: {date.toLocaleDateString()}
@@ -396,7 +352,7 @@ export const ShouldNotCloseOnSelect: Story = {
 };
 
 export const FixedHeight: Story = {
-  render: (args) => {
+  render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [date, setDate] = useState<Date | null>(null);
     return (
@@ -409,7 +365,7 @@ export const FixedHeight: Story = {
         }}
       >
         <div>DatePicker with fixed height calendar:</div>
-        <DatePicker {...args} fixedHeight={true} value={date} onChange={setDate} />
+        <DatePicker fixedHeight value={date} onChange={setDate} />
         {date && (
           <div style={{ fontSize: '12px', color: '#666' }}>
             Selected: {date.toLocaleDateString()}

--- a/src/components/datePicker/datePicker.tsx
+++ b/src/components/datePicker/datePicker.tsx
@@ -1,8 +1,8 @@
 import { default as ReactDatePicker } from 'react-datepicker/dist/es/index.js';
 import { ReactDatePickerCustomHeaderProps } from 'react-datepicker';
 import classNames from 'classnames/bind';
-import { FC, ReactNode, useRef, ReactElement } from 'react';
-import { FieldText } from '@components/fieldText';
+import { FC, ReactNode, useRef, ReactElement, forwardRef } from 'react';
+import { FieldText, FieldTextProps } from '@components/fieldText';
 import { DatePickerHeader } from './header/datePickerHeader';
 import styles from './datePicker.module.scss';
 
@@ -10,17 +10,17 @@ const cx = classNames.bind(styles);
 
 const DEFAULT_LANGUAGE = 'en';
 const DEFAULT_DATE_FORMAT = 'MM-dd-yyyy';
+const DATE_RANGE_SEPARATOR = ' to ';
 
-interface DatePickerProps {
-  onChange?: (date: Date | null) => void;
+type DateRangeValue = [Date | null, Date | null];
+
+interface DatePickerBaseProps {
   onBlur?: () => void;
   onFocus?: () => void;
   headerNodes?: ReactNode;
   disabled?: boolean;
   shouldCloseOnSelect?: boolean;
   fixedHeight?: boolean;
-  startDate?: Date | undefined;
-  endDate?: Date | undefined;
   customClassName?: string;
   popperClassName?: string;
   calendarClassName?: string;
@@ -29,85 +29,136 @@ interface DatePickerProps {
   yearsOptions?: number[];
   placeholder?: string;
   dateFormat?: string;
-  selects?: 'start' | 'end' | 'none';
-  value?: Date | null;
 }
 
-export const DatePicker: FC<DatePickerProps> = ({
-  onChange = () => {},
-  disabled = false,
-  onBlur = () => {},
-  onFocus = () => {},
-  endDate = undefined,
-  startDate = undefined,
-  headerNodes = null,
-  customClassName = '',
-  customTimeInput = undefined,
-  shouldCloseOnSelect = true,
-  popperClassName = '',
-  calendarClassName = '',
-  fixedHeight = false,
-  language = DEFAULT_LANGUAGE,
-  yearsOptions = [],
-  placeholder = DEFAULT_DATE_FORMAT.toUpperCase(),
-  dateFormat = DEFAULT_DATE_FORMAT,
-  selects = 'start',
-  value = null,
-}) => {
+interface DatePickerSingleProps extends DatePickerBaseProps {
+  selectsRange?: false;
+  value?: Date | null;
+  onChange?: (date: Date | null) => void;
+}
+
+interface DatePickerRangeProps extends DatePickerBaseProps {
+  selectsRange: true;
+  value?: DateRangeValue;
+  onChange?: (dates: DateRangeValue) => void;
+}
+
+type DatePickerProps = DatePickerSingleProps | DatePickerRangeProps;
+
+const RangeInput = forwardRef<HTMLInputElement, FieldTextProps>(({ value, ...rest }, ref) => {
+  const formattedValue = value?.replace(' - ', DATE_RANGE_SEPARATOR) ?? '';
+  return <FieldText {...rest} value={formattedValue} ref={ref} />;
+});
+
+export const DatePicker: FC<DatePickerProps> = (props) => {
+  const {
+    onChange = () => {},
+    disabled = false,
+    onBlur = () => {},
+    onFocus = () => {},
+    headerNodes = null,
+    customClassName = '',
+    customTimeInput = undefined,
+    shouldCloseOnSelect = true,
+    popperClassName = '',
+    calendarClassName = '',
+    fixedHeight = false,
+    language = DEFAULT_LANGUAGE,
+    yearsOptions = [],
+    dateFormat = DEFAULT_DATE_FORMAT,
+    value = null,
+  } = props;
+
+  const selectsRange = 'selectsRange' in props && props.selectsRange === true;
   const inputRef = useRef(null);
+
+  const startDate = selectsRange ? ((value as DateRangeValue)?.[0] ?? undefined) : undefined;
+  const endDate = selectsRange ? ((value as DateRangeValue)?.[1] ?? undefined) : undefined;
+
   const startDateString = startDate?.toDateString();
   const endDateString = endDate?.toDateString();
   const isValidEndDate = endDate && startDate && endDate > startDate;
 
+  const defaultPlaceholder = selectsRange
+    ? `${DEFAULT_DATE_FORMAT.toUpperCase()} to ${DEFAULT_DATE_FORMAT.toUpperCase()}`
+    : DEFAULT_DATE_FORMAT.toUpperCase();
+  const placeholder = props.placeholder ?? defaultPlaceholder;
+
   const getDayClassName = (displayedDates: Date) => {
+    if (!selectsRange) {
+      const selectedDate = (value as Date | null)?.toDateString();
+      const displayedDateString = displayedDates.toDateString();
+      return cx('date', {
+        'current-date': displayedDateString === selectedDate,
+        disabled,
+      });
+    }
+
     const displayedDateString = displayedDates.toDateString();
     const isCurrentDate = displayedDateString === startDateString;
-    const isEndDate = isValidEndDate && displayedDateString === endDateString;
-
+    const isEndDateMatch = isValidEndDate && displayedDateString === endDateString;
     const isInsideSelectedRange =
       startDate && endDate && displayedDates > startDate && displayedDates < endDate;
 
     return cx('date', {
       'current-date': isCurrentDate,
-      'selected-range': isInsideSelectedRange && !isEndDate,
-      'end-date': isEndDate && isValidEndDate,
+      'selected-range': isInsideSelectedRange && !isEndDateMatch,
+      'end-date': isEndDateMatch && isValidEndDate,
       disabled,
     });
   };
 
+  const customInput = selectsRange ? (
+    <RangeInput className={cx('input', 'input-range')} defaultWidth={false} ref={inputRef} />
+  ) : (
+    <FieldText className={cx('input')} defaultWidth={false} ref={inputRef} />
+  );
+
+  const commonProps = {
+    customInput,
+    placeholderText: placeholder,
+    disabled,
+    shouldCloseOnSelect,
+    fixedHeight,
+    locale: language,
+    showPopperArrow: false,
+    dayClassName: getDayClassName,
+    calendarClassName: cx(calendarClassName, 'calendar'),
+    renderCustomHeader: (customHeaderProps: ReactDatePickerCustomHeaderProps) => (
+      <DatePickerHeader
+        {...customHeaderProps}
+        headerNodes={headerNodes}
+        customClassName={customClassName}
+        yearsOptions={yearsOptions}
+        locale={language}
+      />
+    ),
+    onBlur,
+    onFocus,
+    customTimeInput,
+    showTimeInput: Boolean(customTimeInput),
+    popperClassName: cx(popperClassName, 'popper'),
+    dateFormat,
+    className: cx('datepicker'),
+  };
+
+  if (selectsRange) {
+    return (
+      <ReactDatePicker
+        {...commonProps}
+        selectsRange
+        startDate={startDate}
+        endDate={endDate}
+        onChange={onChange as (dates: DateRangeValue) => void}
+      />
+    );
+  }
+
   return (
     <ReactDatePicker
-      customInput={<FieldText className={cx('input')} defaultWidth={false} ref={inputRef} />}
-      placeholderText={placeholder}
-      selected={value}
-      startDate={startDate}
-      endDate={endDate}
-      disabled={disabled}
-      shouldCloseOnSelect={shouldCloseOnSelect}
-      fixedHeight={fixedHeight}
-      locale={language}
-      showPopperArrow={false}
-      dayClassName={getDayClassName}
-      calendarClassName={cx(calendarClassName, 'calendar')}
-      renderCustomHeader={(customHeaderProps: ReactDatePickerCustomHeaderProps) => (
-        <DatePickerHeader
-          {...customHeaderProps}
-          headerNodes={headerNodes}
-          customClassName={customClassName}
-          yearsOptions={yearsOptions}
-          locale={language}
-        />
-      )}
-      onChange={onChange}
-      onBlur={onBlur}
-      onFocus={onFocus}
-      customTimeInput={customTimeInput}
-      showTimeInput={Boolean(customTimeInput)}
-      popperClassName={cx(popperClassName, 'popper')}
-      dateFormat={dateFormat}
-      selectsStart={selects === 'start'}
-      selectsEnd={selects === 'end'}
-      className={cx('datepicker')}
+      {...commonProps}
+      selected={value as Date | null}
+      onChange={onChange as (date: Date | null) => void}
     />
   );
 };

--- a/src/components/datePicker/datePicker.tsx
+++ b/src/components/datePicker/datePicker.tsx
@@ -1,7 +1,7 @@
 import { default as ReactDatePicker } from 'react-datepicker/dist/es/index.js';
 import { ReactDatePickerCustomHeaderProps } from 'react-datepicker';
 import classNames from 'classnames/bind';
-import { FC, ReactNode, useRef, ReactElement, forwardRef } from 'react';
+import { ReactNode, useRef, ReactElement, forwardRef } from 'react';
 import { FieldText, FieldTextProps } from '@components/fieldText';
 import { DatePickerHeader } from './header/datePickerHeader';
 import styles from './datePicker.module.scss';
@@ -50,7 +50,7 @@ const RangeInput = forwardRef<HTMLInputElement, FieldTextProps>(({ value, ...res
   return <FieldText {...rest} value={formattedValue} ref={ref} />;
 });
 
-export const DatePicker: FC<DatePickerProps> = (props) => {
+export const DatePicker = (props: DatePickerProps) => {
   const {
     onChange = () => {},
     disabled = false,

--- a/src/components/datePicker/header/datePickerHeader.module.scss
+++ b/src/components/datePicker/header/datePickerHeader.module.scss
@@ -57,13 +57,13 @@
       width: 117px;
     }
 
-    .toggle-button > span {
+    .toggle-button span {
       color: var(--rp-ui-base-topaz);
       font-family: var(--rp-ui-base-font-family);
       font-weight: var(--rp-ui-base-fw-bold);
     }
 
-    .toggle-button:hover > span {
+    .toggle-button:hover span {
       color: var(-rp-ui-base-topaz-hover);
     }
   }

--- a/src/components/datePicker/header/datePickerHeader.module.scss
+++ b/src/components/datePicker/header/datePickerHeader.module.scss
@@ -64,7 +64,7 @@
     }
 
     .toggle-button:hover span {
-      color: var(-rp-ui-base-topaz-hover);
+      color: var(--rp-ui-base-topaz-hover);
     }
   }
 }

--- a/src/components/fieldText/index.ts
+++ b/src/components/fieldText/index.ts
@@ -1,5 +1,6 @@
-import { FieldText } from './fieldText';
+import { FieldText, FieldTextProps } from './fieldText';
 
 export { FieldText };
+export type { FieldTextProps };
 
 export default FieldText;


### PR DESCRIPTION
**Visuals**

<img width="330" height="870" alt="Screenshot 2026-01-27 at 22 49 39" src="https://github.com/user-attachments/assets/8ef048e1-fc7c-491f-92bb-f1013923e1ad" />

<img width="465" height="526" alt="Screenshot 2026-01-27 at 22 50 07" src="https://github.com/user-attachments/assets/01850705-c957-47b8-8b4b-73d8afebe29b" />

**Dependent PRs**:
Service UI - https://github.com/reportportal/service-ui/pull/4897
Test Executions - https://git.epam.com/EPM-RPP/plugin-test-execution/-/merge_requests/114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DatePicker supports selecting a date range in a single field for simpler range entry.

* **Improvements**
  * Updated hover, selected-range, and current-date visuals for clearer selection feedback.
  * Added a public input-range style to improve sizing and layout in range mode.
  * Storybook examples and controls updated to reflect single-field range usage and explicit prop handling.

* **API**
  * Field text props are now exported for external use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->