### PR TITLE
EPMRPP-111251 || Add css class for popover in FilterItem component

### DIFF
--- a/src/components/filterItem/filterItem.tsx
+++ b/src/components/filterItem/filterItem.tsx
@@ -29,6 +29,7 @@ export interface FilterItemProps {
   onHover?: (id: string, isHovering: boolean) => void;
   className?: string;
   captionClassName?: string;
+  popoverClassName?: string;
   disabled?: boolean;
   selected?: boolean;
   editMode?: boolean;
@@ -42,6 +43,7 @@ export const FilterItem = ({
   onHover,
   className,
   captionClassName,
+  popoverClassName,
   disabled = false,
   selected = false,
   editMode = false,
@@ -135,6 +137,7 @@ export const FilterItem = ({
           items={actions}
           disabled={disabled || editMode}
           buttonClassName={cx('actions-button')}
+          popoverClassName={popoverClassName}
           placement="bottom-start"
         />
       </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,6 @@
 export { AdaptiveTagList } from './adaptiveTagList';
 export { ActionMenu, ActionMenuItem } from './actionMenu';
 export { ACTION_MENU_DIVIDER } from './actionMenu/constants';
-export type { ActionMenuProps, ActionItem, DividerItem, MenuItem } from './actionMenu';
 export { AttachedFile } from './attachedFile';
 export { BaseIconButton } from './baseIconButton';
 export { Breadcrumbs } from './breadcrumbs';
@@ -19,7 +18,6 @@ export { FieldTextFlex } from './fieldTextFlex';
 export { FileDropArea } from './fileDropArea';
 export { FiltersButton } from './filtersButton';
 export { FilterItem } from './filterItem';
-export type { FilterItemProps } from './filterItem';
 export { IssueList } from './issueList';
 export { Modal } from './modal';
 export { MultipleAutocomplete } from './autocompletes/multipleAutocomplete';


### PR DESCRIPTION
## Description

* Added prop `popoverClassName` to FilterItem component, to add possibility to customise popover in the child ActionMenu componrny
* Removed unnecessary types exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter components now support customizable popover styling through a new optional prop, allowing teams to apply their own CSS classes and maintain visual consistency across applications.

* **Breaking Changes**
  * Component type interfaces are no longer publicly exported, which may require updates to code that explicitly imports and references these types for type annotations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->