### PR TITLE
EPMRPP-111276 || Add overlay functionality to SidePanel component

### DIFF
--- a/src/components/sidePanel/sidePanel.module.scss
+++ b/src/components/sidePanel/sidePanel.module.scss
@@ -1,5 +1,29 @@
 @import 'src/assets/styles/mixins/font-scale';
 
+.side-panel-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+    pointer-events: none;
+
+    &.active {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
+.overlay-default {
+    background-color: var(--rp-ui-base-overlay);
+}
+
+.overlay-light-cyan {
+    background-color: var(--rp-ui-base-overlay-light-cyan);
+}
+
 .side-panel {
     position: fixed;
     display: flex;

--- a/src/components/sidePanel/sidePanel.stories.tsx
+++ b/src/components/sidePanel/sidePanel.stories.tsx
@@ -17,6 +17,36 @@ const meta: Meta<typeof SidePanel> = {
     layout: 'fullscreen',
   },
   tags: ['autodocs'],
+  argTypes: {
+    showOverlay: {
+      control: 'boolean',
+      description: 'Show overlay behind the panel',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    overlay: {
+      control: { type: 'select', options: ['default', 'light-cyan'] },
+      description: 'Overlay color variant',
+      table: {
+        defaultValue: { summary: 'default' },
+      },
+      if: { arg: 'showOverlay', truthy: true },
+    },
+    allowCloseOutside: {
+      control: 'boolean',
+      description: 'Allow closing panel by clicking outside',
+      table: {
+        defaultValue: { summary: 'true' },
+      },
+      if: { arg: 'showOverlay', truthy: true },
+    },
+    overlayClassName: {
+      control: 'text',
+      description: 'Custom className for overlay element',
+      if: { arg: 'showOverlay', truthy: true },
+    },
+  },
 };
 
 export default meta;
@@ -466,21 +496,27 @@ const INITIAL_FILTERS = {
   patternName: '',
 };
 
-export const Example2 = {
+export const WithFormAndClickOutside = {
   render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [isOpen, setIsOpen] = useState(true);
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [filters, setFilters] = useState(INITIAL_FILTERS);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isDirty, setIsDirty] = useState(false);
 
     type Filters = typeof INITIAL_FILTERS;
     const updateFilter =
       <K extends keyof Filters>(key: K) =>
       (value: string | number | boolean | (string | number | boolean)[]) => {
         setFilters((prev) => ({ ...prev, [key]: String(value) }));
+        setIsDirty(true);
       };
 
-    const handleClearFilters = () => setFilters(INITIAL_FILTERS);
+    const handleClearFilters = () => {
+      setFilters(INITIAL_FILTERS);
+      setIsDirty(false);
+    };
 
     return (
       <div>
@@ -488,11 +524,20 @@ export const Example2 = {
           <Button onClick={() => setIsOpen(!isOpen)}>
             {isOpen ? 'Close Panel' : 'Open Panel'}
           </Button>
+          {isDirty && (
+            <div
+              style={{ marginTop: '8px', color: 'var(--rp-ui-base-warning)', fontWeight: 'bold' }}
+            >
+              Form has unsaved changes. Click outside is disabled.
+            </div>
+          )}
         </div>
         <SidePanel
           className="example-2"
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
+          showOverlay={true}
+          allowCloseOutside={!isDirty}
           title="Filter"
           contentComponent={
             <div className="filter-content">
@@ -623,11 +668,83 @@ export const Example2 = {
                 Clear all filters
               </Button>
               <div className="filter-footer-actions">
-                <Button variant="ghost" onClick={() => setIsOpen(false)}>
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setIsOpen(false);
+                    setIsDirty(false);
+                  }}
+                >
                   Cancel
                 </Button>
-                <Button>Apply</Button>
+                <Button
+                  onClick={() => {
+                    setIsOpen(false);
+                    setIsDirty(false);
+                  }}
+                >
+                  Apply
+                </Button>
               </div>
+            </div>
+          }
+        />
+      </div>
+    );
+  },
+} satisfies Story;
+
+export const WithOverlay = {
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isOpen, setIsOpen] = useState(true);
+
+    return (
+      <div>
+        <div className="control-wrapper">
+          <Button onClick={() => setIsOpen(!isOpen)}>
+            {isOpen ? 'Close Panel' : 'Open Panel'}
+          </Button>
+        </div>
+        <SidePanel
+          className="example-2"
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          showOverlay={true}
+          title="Panel with overlay"
+          contentComponent={
+            <div className="filter-content">
+              <p>Background is blocked. Overlay is shown.</p>
+            </div>
+          }
+        />
+      </div>
+    );
+  },
+} satisfies Story;
+
+export const LightCyanOverlay = {
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [isOpen, setIsOpen] = useState(true);
+
+    return (
+      <div>
+        <div className="control-wrapper">
+          <Button onClick={() => setIsOpen(!isOpen)}>
+            {isOpen ? 'Close Panel' : 'Open Panel'}
+          </Button>
+        </div>
+        <SidePanel
+          className="example-2"
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          showOverlay={true}
+          overlay="light-cyan"
+          title="Panel with light cyan overlay"
+          contentComponent={
+            <div className="filter-content">
+              <p>Light cyan overlay variant.</p>
             </div>
           }
         />

--- a/src/components/sidePanel/sidePanel.tsx
+++ b/src/components/sidePanel/sidePanel.tsx
@@ -1,6 +1,8 @@
-import { ReactNode, useEffect, useId } from 'react';
+import { ReactNode, useEffect, useId, useRef, useMemo } from 'react';
 import classNames from 'classnames/bind';
 import { KeyCodes } from '@common/constants/keyCodes';
+import { useOnClickOutside } from '@common/hooks';
+import { DROPDOWN_PORTAL_MENU_ATTR } from '@components/dropdown';
 import { CloseIcon } from '@components/icons';
 import { BaseIconButton } from '@components/baseIconButton';
 import styles from './sidePanel.module.scss';
@@ -19,6 +21,10 @@ export interface SidePanelProps {
   isOpen?: boolean;
   onClose?: () => void;
   closeButtonAriaLabel?: string;
+  showOverlay?: boolean;
+  overlay?: 'default' | 'light-cyan';
+  allowCloseOutside?: boolean;
+  overlayClassName?: string;
 }
 
 export const SidePanel = ({
@@ -33,12 +39,30 @@ export const SidePanel = ({
   isOpen = true,
   onClose,
   closeButtonAriaLabel = 'Close panel',
+  showOverlay = false,
+  overlay = 'default',
+  allowCloseOutside = true,
+  overlayClassName,
 }: SidePanelProps) => {
   const titleId = useId();
+  const panelRef = useRef<HTMLElement>(null);
 
   const handleClose = () => {
     onClose?.();
   };
+
+  const clickOutsideOptions = useMemo(
+    () => ({
+      ignoreSelectors: [`[${DROPDOWN_PORTAL_MENU_ATTR}]`],
+    }),
+    [],
+  );
+
+  useOnClickOutside(
+    panelRef,
+    allowCloseOutside && showOverlay && isOpen ? onClose : undefined,
+    clickOutsideOptions,
+  );
 
   useEffect(() => {
     if (!isOpen || !onClose) {
@@ -48,7 +72,7 @@ export const SidePanel = ({
     const onKeydown = (event: KeyboardEvent) => {
       const { keyCode } = event;
 
-      if (keyCode === KeyCodes.ESCAPE_KEY_CODE) {
+      if (keyCode === KeyCodes.ESCAPE_KEY_CODE && allowCloseOutside) {
         onClose();
       }
     };
@@ -58,12 +82,13 @@ export const SidePanel = ({
     return () => {
       document.removeEventListener('keydown', onKeydown, false);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, allowCloseOutside]);
 
   const hasHeaderOrDescription = !!(headerComponent || descriptionComponent);
 
-  return (
+  const panelElement = (
     <aside
+      ref={panelRef}
       className={cx('side-panel', `side-${side}`, { active: isOpen }, className)}
       role="dialog"
       aria-modal="true"
@@ -108,6 +133,23 @@ export const SidePanel = ({
       )}
     </aside>
   );
+
+  if (showOverlay && isOpen) {
+    return (
+      <div
+        className={cx(
+          'side-panel-overlay',
+          { active: isOpen },
+          overlay && `overlay-${overlay}`,
+          overlayClassName,
+        )}
+      >
+        {panelElement}
+      </div>
+    );
+  }
+
+  return panelElement;
 };
 
 export default SidePanel;

--- a/src/components/sidePanel/sidePanel.tsx
+++ b/src/components/sidePanel/sidePanel.tsx
@@ -134,7 +134,7 @@ export const SidePanel = ({
     </aside>
   );
 
-  if (showOverlay && isOpen) {
+  if (showOverlay) {
     return (
       <div
         className={cx(


### PR DESCRIPTION
# SidePanel Overlay Feature

## Summary

Added overlay functionality to `SidePanel` component (opt-in, disabled by default).

---

## What Changed

### Before
- `SidePanel` had no overlay
- Areas outside panel remained interactive (clicks, scrolling, etc.)
- Panel appeared on top of content without blocking background

### After
- `SidePanel` can optionally show overlay (`showOverlay={false}` by default)
- When overlay enabled, clicking outside panel closes it by default (`allowCloseOutside={true}`)
- Overlay covers entire screen (`position: fixed, top: 0`)
- Background is blocked from interaction when panel is open with overlay

---

## New Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `showOverlay` | `boolean` | `false` | Show overlay behind the panel |
| `overlay` | `'default' \| 'light-cyan'` | `'default'` | Overlay color variant |
| `allowCloseOutside` | `boolean` | `true` | Allow closing by clicking outside (only when overlay is shown) |
| `overlayClassName` | `string` | `undefined` | Custom className for overlay element (can be used for z-index) |

---

## Usage Guide

### Enable Overlay

To enable overlay (new feature):

```tsx
<SidePanel
  showOverlay
  {...otherProps}
/>
```

### Prevent Closing on Outside Click

If you want overlay but prevent closing when clicking outside:

```tsx
<SidePanel
  showOverlay
  allowCloseOutside={false}
  {...otherProps}
/>
```

### Use Light Cyan Overlay

```tsx
<SidePanel
  showOverlay
  overlay="light-cyan"
  {...otherProps}
/>
```

### Custom z-index

If you need to control z-index (e.g., to layer multiple panels):

```tsx
<SidePanel
  showOverlay={true}
  className="my-panel"
  overlayClassName="my-overlay"
  {...otherProps}
/>
```

```css
.my-overlay {
  z-index: 9;
}

.my-panel {
  z-index: 10;
}
```

---

## Technical Details

### Overlay Implementation

- Overlay uses same CSS variables as `Modal` component:
  - `var(--rp-ui-base-overlay)` for default
  - `var(--rp-ui-base-overlay-light-cyan)` for light-cyan variant
- z-index management:
  - Can be controlled via `className` (for panel) and `overlayClassName` (for overlay)
  - No default z-index in CSS - allows existing implementations to continue working
  - Example: `.my-panel { z-index: 10; }` and `.my-overlay { z-index: 9; }`
- Transition: `0.3s ease-in-out` (matches panel animation)

### Click Outside Logic

- Uses `useOnClickOutside` hook (same as Modal)
- Ignores clicks on dropdown portal menus (via `DROPDOWN_PORTAL_MENU_ATTR`)
- Only active when:
  - `showOverlay === true`
  - `allowCloseOutside === true`
  - `isOpen === true`

### Keyboard Behavior

- ESC key closes panel only when `allowCloseOutside={true}`
- This ensures consistent behavior: if clicking outside is blocked (e.g., form has unsaved changes), ESC is also blocked

---

## Notes

- **Not a breaking change**: Default behavior remains unchanged (`showOverlay={false}`)
- Overlay is opt-in to avoid breaking existing implementations

---

## Storybook

Stories updated:
- `Example1` - default behavior without overlay
- `WithFormAndClickOutside` - demonstrates overlay with form dirty state (`allowCloseOutside={!isDirty}`)
- `WithOverlay` - demonstrates basic overlay usage
- `LightCyanOverlay` - demonstrates light cyan overlay variant

## Visuals

<img width="1622" height="650" alt="image" src="https://github.com/user-attachments/assets/91bda673-4ca5-46a4-9f4c-7673c999ed70" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side panels can display an overlay (default or light-cyan) with configurable class and optional outside-click/ESC-to-close control.
  * Forms in side panels now show an “unsaved changes” warning and prevent outside-close when needed.

* **Documentation**
  * Stories updated with controls for overlay, allowCloseOutside, overlayClassName; renamed/expanded examples to showcase new behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->