### PR TITLE
EPMRPP-111842 || Fix item pluralization in the Bulk Panel

### DIFF
--- a/src/components/bulkPanel/bulkPanel.tsx
+++ b/src/components/bulkPanel/bulkPanel.tsx
@@ -22,11 +22,11 @@ const DEFAULT_CAPTIONS = {
   ineligibleTab: 'Ineligible Items',
   ineligibleInfoMessage: (count: number) => (
     <>
-      You have <b>{count}</b> ineligible items
+      You have <b>{count}</b> ineligible item{count === 1 ? '' : 's'}
     </>
   ),
   cancelButton: (actionLabel: string) => `Cancel "${actionLabel}"`,
-  proceedButton: (count: number) => `Proceed with ${count} Eligible Items`,
+  proceedButton: (count: number) => `Proceed with ${count} Eligible Item${count === 1 ? '' : 's'}`,
 };
 
 const TABS = {


### PR DESCRIPTION
## LInks
[EPMRPP-111842](https://jiraeu.epam.com/browse/EPMRPP-111842)

## Visuals
<img width="628" height="121" alt="Screenshot 2026-01-30 093339" src="https://github.com/user-attachments/assets/5e12e6d8-97a5-4abb-8ec1-f1db38950e34" />
<img width="577" height="135" alt="Screenshot 2026-01-30 093351" src="https://github.com/user-attachments/assets/2daba8ca-e8cd-4fe3-90ad-5f2c93d34f01" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pluralization in UI captions to correctly display singular ("Eligible Item", "ineligible item") and plural forms ("Eligible Items", "ineligible items") based on item count.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->