### PR TITLE
EPMRPP-112010 || Fix css for outline icon in FiltersButton

### DIFF
--- a/src/components/filtersButton/filtersButton.module.scss
+++ b/src/components/filtersButton/filtersButton.module.scss
@@ -79,7 +79,6 @@ $MAX-CAPTION-WIDTH: 120px;
       svg {
         path {
           fill: var(--rp-ui-base-topaz);
-          stroke: var(--rp-ui-base-topaz);
         }
       }
     }
@@ -97,7 +96,6 @@ $MAX-CAPTION-WIDTH: 120px;
         svg {
           path {
             fill: var(--rp-ui-base-topaz-pressed);
-            stroke: var(--rp-ui-base-topaz-pressed);
           }
         }
       }
@@ -112,7 +110,6 @@ $MAX-CAPTION-WIDTH: 120px;
         svg {
           path {
             fill: var(--rp-ui-base-topaz-hover);
-            stroke: var(--rp-ui-base-topaz-hover);
           }
         }
       }

--- a/src/components/filtersButton/filtersButton.tsx
+++ b/src/components/filtersButton/filtersButton.tsx
@@ -62,7 +62,7 @@ export const FiltersButton = forwardRef<HTMLButtonElement, FiltersButtonProps>(
     return (
       <button type={type} className={containerClassName} ref={ref} {...rest}>
         <span className={cx('filter-icon')}>
-          {hasAppliedFilters || hasText ? <FilterFilledIcon /> : <FilterOutlineIcon />}
+          {hasAppliedFilters ? <FilterFilledIcon /> : <FilterOutlineIcon />}
         </span>
         {hasText ? (
           <span


### PR DESCRIPTION
## Description

- fixed logix to choose between ontline and filled icons
- removed unnecessary css instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined filters button appearance with updated visual styling
  * Improved filters button icon display to accurately show when filters are applied versus when text is entered

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->