### PR TITLE
fix: adjust dnd three support moving

### DIFF
--- a/src/common/hooks/useTreeSortable.ts
+++ b/src/common/hooks/useTreeSortable.ts
@@ -27,11 +27,10 @@ import type {
 } from '@common/types';
 import { TREE_DROP_POSITIONS } from '@common/types';
 
-const EDGE_ZONE_SIZE = 2;
-
 const calculateDropPosition = (
   clientOffset: { x: number; y: number } | null,
   dropTargetRect: DOMRect | null,
+  isLast = false,
 ): TreeDropPosition => {
   if (!clientOffset || !dropTargetRect) {
     return null;
@@ -39,12 +38,25 @@ const calculateDropPosition = (
 
   const { top, height } = dropTargetRect;
   const relativeY = clientOffset.y - top;
+  const relativeYPercent = relativeY / height;
 
-  if (relativeY < EDGE_ZONE_SIZE) {
+  if (relativeY < 0 && relativeY >= -5) {
     return TREE_DROP_POSITIONS.BEFORE;
   }
 
-  if (relativeY > height - EDGE_ZONE_SIZE) {
+  if (relativeY > height && relativeY <= height + 5) {
+    return isLast ? TREE_DROP_POSITIONS.AFTER : TREE_DROP_POSITIONS.BEFORE;
+  }
+
+  if (relativeY < 0 || relativeY > height) {
+    return null;
+  }
+
+  if (relativeYPercent <= 0.1) {
+    return TREE_DROP_POSITIONS.BEFORE;
+  }
+
+  if (isLast && relativeYPercent >= 0.9) {
     return TREE_DROP_POSITIONS.AFTER;
   }
 
@@ -58,6 +70,7 @@ export const useTreeSortable = ({
   type = DEFAULT_SORTABLE_TYPE,
   isDisabled = false,
   acceptDrop = true,
+  isLast = false,
   canDropOn,
   onDrop,
   hideDefaultPreview = false,
@@ -92,21 +105,22 @@ export const useTreeSortable = ({
           draggedItem?.id !== id &&
           acceptDrop &&
           (!canDropOn || !draggedItem || canDropOn(draggedItem, id));
-        const isCurrentlyOver = canDrop ? monitor.isOver({ shallow: true }) : false;
+
+        const isDirectlyOver = canDrop && monitor.isOver({ shallow: true });
 
         let position: TreeDropPosition = null;
 
-        if (isCurrentlyOver && dropTargetRef.current) {
+        if (isDirectlyOver && dropTargetRef.current) {
           const clientOffset = monitor.getClientOffset();
           const rect = dropTargetRef.current.getBoundingClientRect();
-          position = calculateDropPosition(clientOffset, rect);
+          position = calculateDropPosition(clientOffset, rect, isLast);
           dropPositionRef.current = position;
         } else {
           dropPositionRef.current = null;
         }
 
         return {
-          isOver: isCurrentlyOver,
+          isOver: isDirectlyOver,
           dropPosition: position,
         };
       },
@@ -128,7 +142,7 @@ export const useTreeSortable = ({
         }
       },
     }),
-    [id, type, acceptDrop, canDropOn, onDrop],
+    [id, type, acceptDrop, isLast, canDropOn, onDrop],
   );
 
   const combinedDropRef = (node: HTMLElement | null) => {

--- a/src/common/hooks/useTreeSortable.ts
+++ b/src/common/hooks/useTreeSortable.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDrag, useDrop, DragSourceMonitor, DropTargetMonitor } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 
@@ -37,26 +37,16 @@ const calculateDropPosition = (
   }
 
   const { top, height } = dropTargetRect;
-  const relativeY = clientOffset.y - top;
-  const relativeYPercent = relativeY / height;
+  const cursorY = clientOffset.y;
+  const relativeY = cursorY - top;
 
-  if (relativeY < 0 && relativeY >= -5) {
+  const EDGE_ZONE = 6;
+
+  if (relativeY >= 0 && relativeY < EDGE_ZONE) {
     return TREE_DROP_POSITIONS.BEFORE;
   }
 
-  if (relativeY > height && relativeY <= height + 5) {
-    return isLast ? TREE_DROP_POSITIONS.AFTER : TREE_DROP_POSITIONS.BEFORE;
-  }
-
-  if (relativeY < 0 || relativeY > height) {
-    return null;
-  }
-
-  if (relativeYPercent <= 0.1) {
-    return TREE_DROP_POSITIONS.BEFORE;
-  }
-
-  if (isLast && relativeYPercent >= 0.9) {
+  if (isLast && relativeY >= height - EDGE_ZONE && relativeY <= height) {
     return TREE_DROP_POSITIONS.AFTER;
   }
 
@@ -78,6 +68,10 @@ export const useTreeSortable = ({
   const dropTargetRef = useRef<HTMLElement | null>(null);
   const dropPositionRef = useRef<TreeDropPosition>(null);
 
+  // CRITICAL FIX: useState for dropPosition to trigger re-renders
+  // React-DND's collect doesn't trigger re-render on getClientOffset() changes (issue #179)
+  const [dropPosition, setDropPosition] = useState<TreeDropPosition>(null);
+
   const [{ isDragging }, dragRef, previewRef] = useDrag(
     () => ({
       type,
@@ -96,32 +90,48 @@ export const useTreeSortable = ({
     }
   }, [hideDefaultPreview, previewRef]);
 
-  const [{ isOver, dropPosition }, dropRef] = useDrop(
+  const [{ isOver }, dropRef] = useDrop(
     () => ({
       accept: type,
+      hover: (draggedItem: TreeDragItem, monitor: DropTargetMonitor) => {
+        if (dropTargetRef.current && draggedItem.id !== id && acceptDrop) {
+          const isValidDropTarget = !canDropOn || canDropOn(draggedItem, id);
+
+          if (isValidDropTarget) {
+            const clientOffset = monitor.getClientOffset();
+            const rect = dropTargetRef.current.getBoundingClientRect();
+
+            if (clientOffset && rect) {
+              const newPosition = calculateDropPosition(clientOffset, rect, isLast);
+
+              if (newPosition !== dropPosition) {
+                setDropPosition(newPosition);
+                dropPositionRef.current = newPosition;
+              }
+            }
+          } else {
+            if (dropPosition !== null) {
+              setDropPosition(null);
+              dropPositionRef.current = null;
+            }
+          }
+        }
+      },
       collect: (monitor: DropTargetMonitor) => {
         const draggedItem = monitor.getItem() as TreeDragItem | null;
-        const canDrop =
-          draggedItem?.id !== id &&
-          acceptDrop &&
-          (!canDropOn || !draggedItem || canDropOn(draggedItem, id));
+        const isBasicDropValid = draggedItem?.id !== id && acceptDrop;
+        const isValidDropTarget = !canDropOn || !draggedItem || canDropOn(draggedItem, id);
 
-        const isDirectlyOver = canDrop && monitor.isOver({ shallow: true });
+        const isDirectlyOverThis = monitor.isOver({ shallow: true });
+        const canDrop = isBasicDropValid && isValidDropTarget;
 
-        let position: TreeDropPosition = null;
-
-        if (isDirectlyOver && dropTargetRef.current) {
-          const clientOffset = monitor.getClientOffset();
-          const rect = dropTargetRef.current.getBoundingClientRect();
-          position = calculateDropPosition(clientOffset, rect, isLast);
-          dropPositionRef.current = position;
-        } else {
+        if (!isDirectlyOverThis && dropPosition !== null) {
+          setDropPosition(null);
           dropPositionRef.current = null;
         }
 
         return {
-          isOver: isDirectlyOver,
-          dropPosition: position,
+          isOver: isDirectlyOverThis && canDrop,
         };
       },
       drop: (draggedItem: TreeDragItem, monitor) => {
@@ -142,7 +152,7 @@ export const useTreeSortable = ({
         }
       },
     }),
-    [id, type, acceptDrop, isLast, canDropOn, onDrop],
+    [id, type, acceptDrop, isLast, canDropOn, onDrop, dropPosition],
   );
 
   const combinedDropRef = (node: HTMLElement | null) => {

--- a/src/common/types/sortableTypes.ts
+++ b/src/common/types/sortableTypes.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, Ref } from 'react';
+import type { ReactNode, Ref, CSSProperties } from 'react';
 import type { XYCoord, ConnectDragSource, ConnectDropTarget, ConnectDragPreview } from 'react-dnd';
 
 export interface SortableItemData {
@@ -123,6 +123,7 @@ export interface UseTreeSortableOptions {
   type?: string;
   isDisabled?: boolean;
   acceptDrop?: boolean;
+  isLast?: boolean;
   canDropOn?: (draggedItem: TreeDragItem, targetId: string | number) => boolean;
   onDrop?: TreeDropHandler;
   hideDefaultPreview?: boolean;
@@ -152,8 +153,8 @@ export interface TreeSortableItemProps {
   acceptDrop?: boolean;
   isLast?: boolean;
   canDropOn?: (draggedItem: TreeDragItem, targetId: string | number) => boolean;
-  depth?: number;
   className?: string;
+  style?: CSSProperties;
   draggingClassName?: string;
   dropBeforeClassName?: string;
   dropInsideClassName?: string;

--- a/src/components/sortable/sortable.stories.tsx
+++ b/src/components/sortable/sortable.stories.tsx
@@ -507,20 +507,20 @@ const FolderNode = ({
   };
 
   return (
-    <TreeSortableItem
-      id={folder.id}
-      index={index}
-      parentId={parentId}
-      type={FOLDER_TYPE}
-      isLast={isLast}
-      canDropOn={canDropOn}
-      onDrop={onDrop}
-      style={{
-        ['--tree-item-indent' as string]: `${depth * 20}px`,
-      }}
-    >
-      {({ isDragging, dragRef }) => (
-        <>
+    <>
+      <TreeSortableItem
+        id={folder.id}
+        index={index}
+        parentId={parentId}
+        type={FOLDER_TYPE}
+        isLast={isLast}
+        canDropOn={canDropOn}
+        onDrop={onDrop}
+        style={{
+          ['--tree-item-indent' as string]: `${depth * 20}px`,
+        }}
+      >
+        {({ isDragging, dragRef }) => (
           <div
             ref={dragRef as Ref<HTMLDivElement>}
             style={{
@@ -553,25 +553,25 @@ const FolderNode = ({
             </span>
             <span style={{ flex: 1 }}>{folder.name}</span>
           </div>
+        )}
+      </TreeSortableItem>
 
-          {isExpanded &&
-            folder.children.map((child, childIndex) => (
-              <FolderNode
-                key={child.id}
-                folder={child}
-                index={childIndex}
-                depth={depth + 1}
-                parentId={folder.id}
-                isLast={childIndex === folder.children.length - 1}
-                expandedIds={expandedIds}
-                onToggle={onToggle}
-                canDropOn={canDropOn}
-                onDrop={onDrop}
-              />
-            ))}
-        </>
-      )}
-    </TreeSortableItem>
+      {isExpanded &&
+        folder.children.map((child, childIndex) => (
+          <FolderNode
+            key={child.id}
+            folder={child}
+            index={childIndex}
+            depth={depth + 1}
+            parentId={folder.id}
+            isLast={childIndex === folder.children.length - 1}
+            expandedIds={expandedIds}
+            onToggle={onToggle}
+            canDropOn={canDropOn}
+            onDrop={onDrop}
+          />
+        ))}
+    </>
   );
 };
 

--- a/src/components/sortable/sortable.stories.tsx
+++ b/src/components/sortable/sortable.stories.tsx
@@ -429,18 +429,23 @@ const getAllFolderNames = (folders: NestedFolder[]): string[] => {
 };
 
 const getNextDuplicateName = (baseName: string, existingNames: string[]): string => {
-  // Remove any existing numeric suffix
-  const baseNameWithoutSuffix = baseName.replace(/\d+$/, '');
+  // Check if name already has "(N)" pattern at the end
+  const numberPattern = /^(.*?)\((\d+)\)$/;
+  const match = baseName.match(numberPattern);
+  const originalName = match ? match[1] : baseName;
 
-  let counter = 1;
-  let newName = `${baseNameWithoutSuffix}${counter}`;
-
-  while (existingNames.includes(newName)) {
-    counter++;
-    newName = `${baseNameWithoutSuffix}${counter}`;
+  // If original name (without number) is not taken, return it
+  if (!existingNames.includes(originalName)) {
+    return originalName;
   }
 
-  return newName;
+  // Find next available number
+  let counter = 1;
+  while (existingNames.includes(`${originalName}(${counter})`)) {
+    counter++;
+  }
+
+  return `${originalName}(${counter})`;
 };
 
 interface FolderNodeProps {

--- a/src/components/sortable/sortable.stories.tsx
+++ b/src/components/sortable/sortable.stories.tsx
@@ -411,6 +411,38 @@ const getFolderName = (folders: NestedFolder[], id: number): string => {
   const folder = findFolderById(folders, id);
   return folder?.name || 'Unknown';
 };
+
+const getAllFolderNames = (folders: NestedFolder[]): string[] => {
+  const names: string[] = [];
+
+  const collectNames = (folderList: NestedFolder[]) => {
+    for (const folder of folderList) {
+      names.push(folder.name);
+      if (folder.children.length > 0) {
+        collectNames(folder.children);
+      }
+    }
+  };
+
+  collectNames(folders);
+  return names;
+};
+
+const getNextDuplicateName = (baseName: string, existingNames: string[]): string => {
+  // Remove any existing numeric suffix
+  const baseNameWithoutSuffix = baseName.replace(/\d+$/, '');
+
+  let counter = 1;
+  let newName = `${baseNameWithoutSuffix}${counter}`;
+
+  while (existingNames.includes(newName)) {
+    counter++;
+    newName = `${baseNameWithoutSuffix}${counter}`;
+  }
+
+  return newName;
+};
+
 interface FolderNodeProps {
   folder: NestedFolder;
   index: number;
@@ -476,52 +508,54 @@ const FolderNode = ({
 
   return (
     <>
-      <div style={{ paddingLeft: `${depth * 20}px` }}>
-        <TreeSortableItem
-          id={folder.id}
-          index={index}
-          parentId={parentId}
-          type={FOLDER_TYPE}
-          isLast={isLast}
-          canDropOn={canDropOn}
-          onDrop={onDrop}
-        >
-          {({ isDragging, dragRef }) => (
-            <div
-              ref={dragRef as Ref<HTMLDivElement>}
+      <TreeSortableItem
+        id={folder.id}
+        index={index}
+        parentId={parentId}
+        type={FOLDER_TYPE}
+        isLast={isLast}
+        canDropOn={canDropOn}
+        onDrop={onDrop}
+        style={{
+          paddingLeft: `${depth * 20}px`,
+          ['--tree-item-indent' as string]: `${depth * 20}px`,
+        }}
+      >
+        {({ isDragging, dragRef }) => (
+          <div
+            ref={dragRef as Ref<HTMLDivElement>}
+            style={{
+              ...folderRowStyle,
+              opacity: isDragging ? 0.4 : isChildOfDragged ? 0.5 : 1,
+              marginBottom: '2px',
+              cursor: isChildOfDragged ? 'not-allowed' : folderRowStyle.cursor,
+              pointerEvents: isChildOfDragged ? 'none' : 'auto',
+            }}
+          >
+            <span
+              onClick={(e) => {
+                e.stopPropagation();
+                if (hasChildren) onToggle(folder.id);
+              }}
               style={{
-                ...folderRowStyle,
-                opacity: isDragging ? 0.4 : isChildOfDragged ? 0.5 : 1,
-                marginBottom: '2px',
-                cursor: isChildOfDragged ? 'not-allowed' : folderRowStyle.cursor,
-                pointerEvents: isChildOfDragged ? 'none' : 'auto',
+                width: '16px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#9ca3af',
+                cursor: hasChildren ? 'pointer' : 'default',
+                visibility: hasChildren ? 'visible' : 'hidden',
               }}
             >
-              <span
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (hasChildren) onToggle(folder.id);
-                }}
-                style={{
-                  width: '16px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  color: '#9ca3af',
-                  cursor: hasChildren ? 'pointer' : 'default',
-                  visibility: hasChildren ? 'visible' : 'hidden',
-                }}
-              >
-                <ChevronIcon isExpanded={isExpanded} />
-              </span>
-              <span style={{ color: '#f59e0b' }}>
-                {isExpanded ? <FolderOpenIcon /> : <FolderIcon />}
-              </span>
-              <span style={{ flex: 1 }}>{folder.name}</span>
-            </div>
-          )}
-        </TreeSortableItem>
-      </div>
+              <ChevronIcon isExpanded={isExpanded} />
+            </span>
+            <span style={{ color: '#f59e0b' }}>
+              {isExpanded ? <FolderOpenIcon /> : <FolderIcon />}
+            </span>
+            <span style={{ flex: 1 }}>{folder.name}</span>
+          </div>
+        )}
+      </TreeSortableItem>
 
       {isExpanded &&
         folder.children.map((child, childIndex) => (
@@ -688,10 +722,12 @@ export const TreeSortableNested: Story = {
       const [, draggedFolder] = removeFolder(folders, draggedItem.id as number);
 
       if (draggedFolder && position) {
+        const existingNames = getAllFolderNames(folders);
+
         // Create a deep copy with new IDs for all folders and subfolders
         const duplicatedFolder = {
           ...cloneFolderWithNewIds(draggedFolder),
-          name: `${draggedFolder.name} (copy)`,
+          name: getNextDuplicateName(draggedFolder.name, existingNames),
         };
 
         const newFolders = insertFolder(folders, targetId as number, duplicatedFolder, position);

--- a/src/components/sortable/sortable.stories.tsx
+++ b/src/components/sortable/sortable.stories.tsx
@@ -507,29 +507,28 @@ const FolderNode = ({
   };
 
   return (
-    <>
-      <TreeSortableItem
-        id={folder.id}
-        index={index}
-        parentId={parentId}
-        type={FOLDER_TYPE}
-        isLast={isLast}
-        canDropOn={canDropOn}
-        onDrop={onDrop}
-        style={{
-          paddingLeft: `${depth * 20}px`,
-          ['--tree-item-indent' as string]: `${depth * 20}px`,
-        }}
-      >
-        {({ isDragging, dragRef }) => (
+    <TreeSortableItem
+      id={folder.id}
+      index={index}
+      parentId={parentId}
+      type={FOLDER_TYPE}
+      isLast={isLast}
+      canDropOn={canDropOn}
+      onDrop={onDrop}
+      style={{
+        ['--tree-item-indent' as string]: `${depth * 20}px`,
+      }}
+    >
+      {({ isDragging, dragRef }) => (
+        <>
           <div
             ref={dragRef as Ref<HTMLDivElement>}
             style={{
               ...folderRowStyle,
-              opacity: isDragging ? 0.4 : isChildOfDragged ? 0.5 : 1,
-              marginBottom: '2px',
+              paddingLeft: `${depth * 20}px`,
+              opacity: isDragging || isChildOfDragged ? 0.4 : 1,
               cursor: isChildOfDragged ? 'not-allowed' : folderRowStyle.cursor,
-              pointerEvents: isChildOfDragged ? 'none' : 'auto',
+              pointerEvents: isDragging || isChildOfDragged ? 'none' : 'auto',
             }}
           >
             <span
@@ -554,25 +553,25 @@ const FolderNode = ({
             </span>
             <span style={{ flex: 1 }}>{folder.name}</span>
           </div>
-        )}
-      </TreeSortableItem>
 
-      {isExpanded &&
-        folder.children.map((child, childIndex) => (
-          <FolderNode
-            key={child.id}
-            folder={child}
-            index={childIndex}
-            depth={depth + 1}
-            parentId={folder.id}
-            isLast={childIndex === folder.children.length - 1}
-            expandedIds={expandedIds}
-            onToggle={onToggle}
-            canDropOn={canDropOn}
-            onDrop={onDrop}
-          />
-        ))}
-    </>
+          {isExpanded &&
+            folder.children.map((child, childIndex) => (
+              <FolderNode
+                key={child.id}
+                folder={child}
+                index={childIndex}
+                depth={depth + 1}
+                parentId={folder.id}
+                isLast={childIndex === folder.children.length - 1}
+                expandedIds={expandedIds}
+                onToggle={onToggle}
+                canDropOn={canDropOn}
+                onDrop={onDrop}
+              />
+            ))}
+        </>
+      )}
+    </TreeSortableItem>
   );
 };
 

--- a/src/components/sortable/treeSortableItem/treeSortableItem.module.scss
+++ b/src/components/sortable/treeSortableItem/treeSortableItem.module.scss
@@ -17,7 +17,7 @@
 @mixin drop-indicator {
   content: '';
   position: absolute;
-  left: 0;
+  left: var(--tree-item-indent, 0);
   right: 0;
   height: 2px;
   background-color: var(--rp-ui-color-primary-focused);
@@ -58,7 +58,7 @@
       content: '';
       position: absolute;
       top: 0;
-      left: 0;
+      left: var(--tree-item-indent, 0);
       right: 0;
       bottom: 0;
       border: 2px dashed var(--rp-ui-color-primary-focused);

--- a/src/components/sortable/treeSortableItem/treeSortableItem.module.scss
+++ b/src/components/sortable/treeSortableItem/treeSortableItem.module.scss
@@ -22,6 +22,7 @@
   height: 2px;
   background-color: var(--rp-ui-color-primary-focused);
   z-index: 10;
+  pointer-events: none;
 }
 
 .tree-sortable-item {

--- a/src/components/sortable/treeSortableItem/treeSortableItem.tsx
+++ b/src/components/sortable/treeSortableItem/treeSortableItem.tsx
@@ -38,6 +38,7 @@ export const TreeSortableItem = ({
   isLast = false,
   canDropOn,
   className,
+  style,
   draggingClassName,
   dropBeforeClassName,
   dropInsideClassName,
@@ -67,6 +68,7 @@ export const TreeSortableItem = ({
     type,
     isDisabled,
     acceptDrop,
+    isLast,
     canDropOn,
     onDrop: handleDrop,
     hideDefaultPreview,
@@ -84,6 +86,7 @@ export const TreeSortableItem = ({
   const showDropBefore =
     (isOver && dropPosition === TREE_DROP_POSITIONS.BEFORE) ||
     (isPendingTarget && pendingPosition === TREE_DROP_POSITIONS.BEFORE);
+
   const showDropInside =
     (isOver && dropPosition === TREE_DROP_POSITIONS.INSIDE) ||
     (isPendingTarget && pendingPosition === TREE_DROP_POSITIONS.INSIDE);
@@ -126,6 +129,7 @@ export const TreeSortableItem = ({
         }
       }}
       className={wrapperClasses}
+      style={style}
     >
       {content}
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop now supports an explicit AFTER placement on the last item and exposes precise drop position feedback.

* **Bug Fixes**
  * Folder duplication now generates unique names across the entire tree to avoid conflicts.

* **Improvements**
  * Improved drag visuals, larger drop-sensitive area, clearer drop indicators, dynamic indentation, and per-item inline styling for finer layout control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->