### PR TITLE
EPMRPP-111250 || Add headerClassName prop to the Modal

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useMemo, useRef, useState, FC } from 'react';
+import { ReactNode, useEffect, useMemo, useRef, useState, ReactElement } from 'react';
 import { Scrollbars } from 'rc-scrollbars';
 import { motion, AnimatePresence } from 'framer-motion';
 import classNames from 'classnames/bind';
@@ -28,6 +28,7 @@ interface ModalProps {
   children?: ReactNode;
   footerNode?: ReactNode;
   className?: string;
+  headerClassName?: string;
   zIndex?: number;
   size?: ModalSize;
   overlay?: ModalOverlay;
@@ -36,18 +37,19 @@ interface ModalProps {
   cancelButton?: ButtonProps;
   scrollable?: boolean;
   withoutFooter?: boolean;
-  createFooter?: (closeHandler: () => void) => ReactNode;
+  createFooter?: ((closeHandler: () => void) => ReactNode) | null;
   description?: ReactNode;
 }
 
 // TODO: Fix issue with modal positioning
-export const Modal: FC<ModalProps> = ({
+export const Modal = ({
   title,
   children,
   footerNode,
   okButton,
   cancelButton,
   className,
+  headerClassName,
   size = 'default',
   onClose = () => {},
   overlay = 'default',
@@ -57,7 +59,7 @@ export const Modal: FC<ModalProps> = ({
   withoutFooter = false,
   createFooter = null,
   description = null,
-}) => {
+}: ModalProps): ReactElement => {
   const [isShown, setShown] = useState(false);
   const [modalHeight, setModalHeight] = useState(0);
   const [initiallyFocused, setInitiallyFocused] = useState(false);
@@ -140,7 +142,12 @@ export const Modal: FC<ModalProps> = ({
             transition={{ duration: 0.3 }}
             onAnimationStart={onFocus}
           >
-            <ModalHeader title={title} onClose={closeModal} withDescription={!!description} />
+            <ModalHeader
+              title={title}
+              onClose={closeModal}
+              withDescription={!!description}
+              headerClassName={headerClassName}
+            />
             {scrollable ? (
               <div className={cx('scrollable-wrapper')}>
                 <Scrollbars

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -146,7 +146,7 @@ export const Modal = ({
               title={title}
               onClose={closeModal}
               withDescription={!!description}
-              headerClassName={headerClassName}
+              className={headerClassName}
             />
             {scrollable ? (
               <div className={cx('scrollable-wrapper')}>

--- a/src/components/modal/modalHeader/modalHeader.tsx
+++ b/src/components/modal/modalHeader/modalHeader.tsx
@@ -10,16 +10,16 @@ interface ModalHeaderProps {
   title?: ReactNode;
   onClose: () => void;
   withDescription?: boolean;
-  headerClassName?: string;
+  className?: string;
 }
 
 export const ModalHeader = ({
   title,
   onClose,
   withDescription = false,
-  headerClassName,
+  className,
 }: ModalHeaderProps): ReactElement => (
-  <div className={cx('modal-header', { 'width-description': withDescription }, headerClassName)}>
+  <div className={cx('modal-header', { 'width-description': withDescription }, className)}>
     <div className={cx('modal-header-content')}>
       {title && <div className={cx('modal-title')}>{title}</div>}
     </div>

--- a/src/components/modal/modalHeader/modalHeader.tsx
+++ b/src/components/modal/modalHeader/modalHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, FC } from 'react';
+import { ReactNode, ReactElement } from 'react';
 import classNames from 'classnames/bind';
 import { BaseIconButton } from '@components/baseIconButton';
 import { CloseIcon } from '@components/icons';
@@ -10,10 +10,16 @@ interface ModalHeaderProps {
   title?: ReactNode;
   onClose: () => void;
   withDescription?: boolean;
+  headerClassName?: string;
 }
 
-export const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose, withDescription = false }) => (
-  <div className={cx('modal-header', { 'width-description': withDescription })}>
+export const ModalHeader = ({
+  title,
+  onClose,
+  withDescription = false,
+  headerClassName,
+}: ModalHeaderProps): ReactElement => (
+  <div className={cx('modal-header', { 'width-description': withDescription }, headerClassName)}>
     <div className={cx('modal-header-content')}>
       {title && <div className={cx('modal-title')}>{title}</div>}
     </div>


### PR DESCRIPTION
## Description

- added headerclassName prop to Modal to customize modal header
- refactored code to remove FC<...> notation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modals now support custom header styling via an optional header class.
  * Modal headers include a visible close button for easier dismissal.

* **Refactor**
  * Component signatures and type declarations updated for clearer internal typing (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->