### PR TITLE
EPMRPP-111882 || Prevent tooltip from showing when focus moves to child elements

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -151,7 +151,10 @@ export const Tooltip: FC<TooltipProps> = ({
         onMouseDown={handleHideTooltip}
         onMouseEnter={handleShowTooltip}
         onMouseLeave={handleHideTooltip}
-        onFocus={handleShowTooltip}
+        onFocus={(e) => {
+          if (e.target !== e.currentTarget) return;
+          handleShowTooltip();
+        }}
         onBlur={handleHideTooltip}
         tabIndex={0}
       >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed tooltip to display only when the triggering element itself receives focus, preventing unwanted tooltip display when focus originates from child elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->