### PR TITLE
EPMRPP-112338 || ESC should always close opened SidePanel

### DIFF
--- a/src/components/sidePanel/sidePanel.tsx
+++ b/src/components/sidePanel/sidePanel.tsx
@@ -72,7 +72,7 @@ export const SidePanel = ({
     const onKeydown = (event: KeyboardEvent) => {
       const { keyCode } = event;
 
-      if (keyCode === KeyCodes.ESCAPE_KEY_CODE && allowCloseOutside) {
+      if (keyCode === KeyCodes.ESCAPE_KEY_CODE) {
         onClose();
       }
     };
@@ -82,7 +82,7 @@ export const SidePanel = ({
     return () => {
       document.removeEventListener('keydown', onKeydown, false);
     };
-  }, [isOpen, onClose, allowCloseOutside]);
+  }, [isOpen, onClose]);
 
   const hasHeaderOrDescription = !!(headerComponent || descriptionComponent);
 


### PR DESCRIPTION
## Description

According to WCAG 2.1, pressing ESC should always close modal/dialog/panel, without any conditions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The side panel now closes consistently when the Escape key is pressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->