### PR TITLE
Add maxShownDescriptors prop to `Breadcrumbs`

### DIFF
--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -3,9 +3,9 @@
 ### Description:
 
 Breadcrumbs with possibility of ellipsis in the middle of each link that exceeds the size.
-Shows the first breadcrumb plus up to 4 additional breadcrumbs (total of 5 maximum).
+By default, shows the first breadcrumb plus up to 4 additional breadcrumbs (total of 5 maximum).
 If there is only 1 link, it displays as a single breadcrumb (not automatically a "back" button).
-If there are more than 5 links, then it shows the first one, hides the middle ones in the meatball menu, and shows the last 4.
+By default, when there are more than 5 links, it shows the first one, hides the middle ones in the meatball menu, and shows the last 4 (this can be configured with `maxShownDescriptors`).
 Optionally displays a tree icon that shows a hierarchical navigation menu in a popover.
 The tree menu reuses the Breadcrumb component for consistent styling and behavior.
 
@@ -20,6 +20,8 @@ The tree menu reuses the Breadcrumb component for consistent styling and behavio
 - **LinkComponent**: _React.ComponentType_, optional, custom link component for navigation
 - **tree**: _array_ of TreeDescriptor, optional, hierarchical tree structure for the tree menu
 - **isBackButton**: _boolean_, optional, default = false. When true and descriptors.length === 1, displays as a back button with left-pointing arrow
+- **isLastClickable**: _boolean_, optional, default = false. When true, the last breadcrumb remains clickable
+- **maxShownDescriptors**: _number_, optional, default = 5. Maximum number of breadcrumbs shown inline before collapsing middle items into the meatball menu
 
 ### TreeDescriptor Interface:
 
@@ -104,9 +106,9 @@ const tree = [
 
 ### Behavior Details:
 
-- **1-5 breadcrumbs**: All breadcrumbs are shown normally
-- **6+ breadcrumbs**: Shows first breadcrumb + meatball menu (containing hidden middle breadcrumbs) + last 4 breadcrumbs
-- **Clickable behavior**: Only the last breadcrumb is non-clickable (represents current page)
+- **1-N breadcrumbs**: All breadcrumbs are shown normally when `descriptors.length <= maxShownDescriptors`
+- **N+1+ breadcrumbs**: Shows first breadcrumb + meatball menu (containing hidden middle breadcrumbs) + last `maxShownDescriptors - 1` breadcrumbs
+- **Clickable behavior**: By default, only the last breadcrumb is non-clickable (represents current page); set `isLastClickable` to make it clickable
 - **Title truncation**: Long titles are automatically truncated with ellipsis based on available space
 
 ### Tree Component Features:

--- a/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -5,6 +5,11 @@ import { TreeDescriptor } from './types';
 const meta: Meta<typeof Breadcrumbs> = {
   title: 'Components/Breadcrumbs',
   component: Breadcrumbs,
+  argTypes: {
+    maxShownDescriptors: {
+      control: { type: 'number', min: 1 },
+    },
+  },
   parameters: {
     layout: 'centered',
   },

--- a/src/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.test.tsx
@@ -64,6 +64,20 @@ describe('Breadcrumbs', () => {
     expect(screen.getAllByTestId('breadcrumb')).toHaveLength(5);
   });
 
+  it('respects custom maxShownDescriptors value', () => {
+    render(<Breadcrumbs descriptors={mockDescriptors} maxShownDescriptors={3} />);
+    expect(screen.getByTestId('hidden-breadcrumbs-trigger')).toBeInTheDocument();
+    expect(screen.getAllByTestId('breadcrumb')).toHaveLength(3);
+  });
+
+  it('keeps first breadcrumb clickable when maxShownDescriptors is 1', () => {
+    render(<Breadcrumbs descriptors={mockDescriptors.slice(0, 3)} maxShownDescriptors={1} />);
+
+    expect(screen.getByTestId('hidden-breadcrumbs-trigger')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('breadcrumb')).toHaveLength(1);
+  });
+
   it('shows correct hidden breadcrumbs content', () => {
     render(<Breadcrumbs descriptors={mockDescriptors} />);
     expect(screen.queryByTestId('hidden-breadcrumbs-content')).not.toBeInTheDocument();

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,13 +1,18 @@
 import classNames from 'classnames/bind';
+import { drop, take } from 'es-toolkit';
+import { isEmpty } from 'es-toolkit/compat';
+
 import { Breadcrumb } from './breadcrumb';
 import { HiddenBreadcrumbs } from './hiddenBreadcrumbs';
 import { Tree } from './tree';
 import { BreadcrumbsProvider } from './breadcrumbsProvider';
-import { BreadcrumbDescriptor, BreadcrumbsProps } from './types';
+import { BreadcrumbsProps } from './types';
+
 import styles from './breadcrumbs.module.scss';
 
 const cx = classNames.bind(styles);
-const MAX_SHOWN_DESCRIPTORS = 5;
+
+const DEFAULT_MAX_SHOWN_DESCRIPTORS = 5;
 
 export const Breadcrumbs = ({
   descriptors = [],
@@ -15,9 +20,14 @@ export const Breadcrumbs = ({
   LinkComponent,
   tree,
   isBackButton = false,
+  isLastClickable = false,
+  maxShownDescriptors = DEFAULT_MAX_SHOWN_DESCRIPTORS,
 }: BreadcrumbsProps) => {
-  const shownDescriptors = [...descriptors];
-  const firstDescriptor = shownDescriptors.shift();
+  const [firstDescriptor, ...remainingDescriptors] = descriptors;
+
+  const normalizedMaxShownDescriptors = Math.max(1, Math.floor(maxShownDescriptors));
+  const visibleTailCount = normalizedMaxShownDescriptors - 1;
+  const hiddenCount = Math.max(0, remainingDescriptors.length - visibleTailCount);
 
   const getBreadcrumbsCountClass = (count: number): string => {
     const suffix = count > 5 ? '6-plus' : count;
@@ -31,16 +41,12 @@ export const Breadcrumbs = ({
       3: 18,
       4: 13,
     };
+
     return widths[breadcrumbsCount] ?? 12;
   })(descriptors.length);
 
-  let hiddenDescriptors: BreadcrumbDescriptor[] = [];
-  if (shownDescriptors.length > MAX_SHOWN_DESCRIPTORS - 1) {
-    hiddenDescriptors = shownDescriptors.splice(
-      0,
-      shownDescriptors.length - (MAX_SHOWN_DESCRIPTORS - 1),
-    );
-  }
+  const hiddenDescriptors = take(remainingDescriptors, hiddenCount);
+  const shownDescriptors = drop(remainingDescriptors, hiddenCount);
 
   return (
     <BreadcrumbsProvider LinkComponent={LinkComponent}>
@@ -68,22 +74,22 @@ export const Breadcrumbs = ({
                   <Breadcrumb
                     descriptor={firstDescriptor}
                     titleTailNumChars={titleTailNumChars}
-                    isClickable={!!shownDescriptors.length}
+                    isClickable={!isEmpty(remainingDescriptors)}
                   />
                 </div>
               )}
-              {hiddenDescriptors.length > 0 && (
+              {!isEmpty(hiddenDescriptors) && (
                 <div className={cx('breadcrumb-item', 'hidden-breadcrumbs')}>
                   <HiddenBreadcrumbs descriptors={hiddenDescriptors} />
                 </div>
               )}
-              {shownDescriptors.length > 0 &&
+              {!isEmpty(shownDescriptors) &&
                 shownDescriptors.map((descriptor, index) => (
                   <div className={cx('breadcrumb-item')} key={index}>
                     <Breadcrumb
                       descriptor={descriptor}
                       titleTailNumChars={titleTailNumChars}
-                      isClickable={index !== shownDescriptors.length - 1}
+                      isClickable={isLastClickable || index !== shownDescriptors.length - 1}
                     />
                   </div>
                 ))}

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -24,4 +24,6 @@ export interface BreadcrumbsProps {
   tree?: TreeDescriptor[];
   dataAutomationId?: string;
   isBackButton?: boolean;
+  isLastClickable?: boolean;
+  maxShownDescriptors?: number;
 }


### PR DESCRIPTION
Allow customizing `maxShownDescriptors` property in `Breadcrumbs`

<img width="1202" height="622" alt="image" src="https://github.com/user-attachments/assets/6eaa22ec-1088-4c9f-bc9d-052cab5f427e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added maxShownDescriptors to customize how many breadcrumbs display before collapsing (default: 5).
  * Added isLastClickable to optionally make the final breadcrumb clickable (default: false).

* **Documentation**
  * Clarified default breadcrumb display rules and documented the two new props and their behaviors.

* **Tests**
  * Added a test verifying custom maxShownDescriptors behavior.

* **Stories**
  * Exposed maxShownDescriptors as a numeric control in the component story.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->