### PR TITLE
Change focus style to focus-visible for better accessibility

### DIFF
--- a/src/components/button/button.module.scss
+++ b/src/components/button/button.module.scss
@@ -28,7 +28,7 @@
     border: 1px solid var(--rp-ui-color-primary-pressed);
     background-color: var(--rp-ui-color-primary-pressed);
   }
-  &:focus:not(.disabled, :active) {
+  &:focus-visible:not(.disabled, :active) {
     border: 2px solid var(--rp-ui-color-primary-focused);
   }
   svg * {

--- a/src/components/button/button.module.scss
+++ b/src/components/button/button.module.scss
@@ -48,7 +48,7 @@
     border: 1px solid var(--rp-ui-color-primary-pressed);
     color: var(--rp-ui-color-primary-pressed);
   }
-  &:focus:not(.disabled, :active) {
+  &:focus-visible:not(.disabled, :active) {
     border: 2px solid var(--rp-ui-color-primary-focused);
     color: var(--rp-ui-color-primary-focused);
   }
@@ -69,7 +69,7 @@
     border: 1px solid var(--rp-ui-color-error-pressed);
     background-color: var(--rp-ui-color-error-pressed);
   }
-  &:focus:not(.disabled, :active) {
+  &:focus-visible:not(.disabled, :active) {
     border: 2px solid var(--rp-ui-color-error-focused);
   }
   svg * {
@@ -97,7 +97,7 @@
       fill: var(--rp-ui-color-primary-pressed);
     }
   }
-  &:focus:not(.disabled, :active) {
+  &:focus-visible:not(.disabled, :active) {
     padding: 0;
     border: 2px solid var(--rp-ui-color-primary-focused);
   }
@@ -118,7 +118,7 @@
     border: 1px solid var(--rp-ui-color-error-pressed);
     color: var(--rp-ui-color-error-pressed);
   }
-  &:focus:not(.disabled, :active) {
+  &:focus-visible:not(.disabled, :active) {
     border: 2px solid var(--rp-ui-color-error-focused);
   }
   svg * {
@@ -146,7 +146,7 @@
       fill: var(--rp-ui-color-error-pressed);
     }
   }
-  &:focus:not(.disabled, :active) {
+  &:focus-visible:not(.disabled, :active) {
     padding: 0;
     border: 2px solid var(--rp-ui-color-error-focused);
   }


### PR DESCRIPTION
## Description

Replace generic :focus focus rules with :focus-visible for button variants so the focus ring only appears for keyboard navigation.
Ensure focus rules exclude .disabled and :active states to avoid showing the ring during presses.
Adjusted focus-related padding/border behavior to avoid layout shift when the focus ring is applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button focus indicator to use the browser's focus-visible heuristic so the focus ring appears for keyboard users while not showing during mouse interactions.
  * Applied across all button variants, preserving existing hover, active, and disabled behaviors for consistent visual states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->