### PR TITLE
Remove hardcoded width from `Breadcrumbs`

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,8 @@
+#storybook-root {
+  width: 100%;
+  max-width: 100%;
+}
+
+.sb-show-main.sb-main-centered #storybook-root {
+  width: 100%;
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,7 @@
 import type { Preview } from '@storybook/react';
 
+import './preview.css';
+
 import ThemeProvider from '../src/components/themeProvider';
 
 const preview: Preview = {

--- a/src/components/breadcrumbs/breadcrumbs.module.scss
+++ b/src/components/breadcrumbs/breadcrumbs.module.scss
@@ -4,26 +4,30 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  width: 740px;
+  width: 100%;
 }
 
 .breadcrumbs {
   flex-shrink: 1;
   min-width: 0;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   height: 100%;
 
   .breadcrumb-item {
     position: relative;
-    display: inline-flex;
+    display: flex;
     align-items: center;
     max-width: 100%;
     @include font-scale();
 
     &:not(.hidden-breadcrumbs) {
-      flex-shrink: 1;
+      flex: 1 1 auto;
       min-width: 0;
+    }
+
+    &.hidden-breadcrumbs {
+      flex: 0 0 auto;
     }
 
     &:not(:last-child) {
@@ -52,22 +56,5 @@
         transform: rotate(180deg);
       }
     }
-  }
-
-  &.breadcrumbs-2 .breadcrumb-item {
-    max-width: 360px;
-  }
-
-  &.breadcrumbs-3 .breadcrumb-item {
-    max-width: 233px;
-  }
-
-  &.breadcrumbs-4 .breadcrumb-item {
-    max-width: 170px;
-  }
-
-  &.breadcrumbs-5 .breadcrumb-item,
-  &.breadcrumbs-6-plus .breadcrumb-item {
-    max-width: 132px;
   }
 }

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -22,17 +22,13 @@ export const Breadcrumbs = ({
   isBackButton = false,
   isLastClickable = false,
   maxShownDescriptors = DEFAULT_MAX_SHOWN_DESCRIPTORS,
+  className,
 }: BreadcrumbsProps) => {
   const [firstDescriptor, ...remainingDescriptors] = descriptors;
 
   const normalizedMaxShownDescriptors = Math.max(1, Math.floor(maxShownDescriptors));
   const visibleTailCount = normalizedMaxShownDescriptors - 1;
   const hiddenCount = Math.max(0, remainingDescriptors.length - visibleTailCount);
-
-  const getBreadcrumbsCountClass = (count: number): string => {
-    const suffix = count > 5 ? '6-plus' : count;
-    return `breadcrumbs-${suffix}`;
-  };
 
   const titleTailNumChars = ((breadcrumbsCount: number) => {
     const widths: Record<number, number> = {
@@ -51,7 +47,7 @@ export const Breadcrumbs = ({
   return (
     <BreadcrumbsProvider LinkComponent={LinkComponent}>
       <div
-        className={cx('breadcrumbs-container')}
+        className={cx('breadcrumbs-container', className)}
         data-automation-id={dataAutomationId}
         data-testid={dataAutomationId}
       >
@@ -68,7 +64,7 @@ export const Breadcrumbs = ({
                 <Tree tree={tree} />
               </div>
             )}
-            <div className={cx('breadcrumbs', getBreadcrumbsCountClass(descriptors.length))}>
+            <div className={cx('breadcrumbs')}>
               {firstDescriptor && (
                 <div className={cx('breadcrumb-item')}>
                   <Breadcrumb

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -26,4 +26,5 @@ export interface BreadcrumbsProps {
   isBackButton?: boolean;
   isLastClickable?: boolean;
   maxShownDescriptors?: number;
+  className?: string;
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/8fd1928c-9788-4f6b-9378-a8d6d170b5c5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumbs component now accepts an optional className prop for custom styling capabilities.

* **Improvements**
  * Breadcrumbs layout improved with flexible width implementation, replacing fixed pixel constraints for enhanced layout adaptability.
  * Enhanced Storybook preview styling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->