### PR TITLE
Allow configuring tail character count for `Breadcrumbs`

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -22,6 +22,7 @@ export const Breadcrumbs = ({
   isBackButton = false,
   isLastClickable = false,
   maxShownDescriptors = DEFAULT_MAX_SHOWN_DESCRIPTORS,
+  titleTailNumChars: customTitleTailNumChars,
   className,
 }: BreadcrumbsProps) => {
   const [firstDescriptor, ...remainingDescriptors] = descriptors;
@@ -54,7 +55,10 @@ export const Breadcrumbs = ({
         {isBackButton && firstDescriptor ? (
           <div className={cx('breadcrumbs')}>
             <div className={cx('breadcrumb-item', 'back-button')} data-testid="back-breadcrumb">
-              <Breadcrumb descriptor={firstDescriptor} titleTailNumChars={titleTailNumChars} />
+              <Breadcrumb
+                descriptor={firstDescriptor}
+                titleTailNumChars={customTitleTailNumChars ?? titleTailNumChars}
+              />
             </div>
           </div>
         ) : (
@@ -69,7 +73,7 @@ export const Breadcrumbs = ({
                 <div className={cx('breadcrumb-item')}>
                   <Breadcrumb
                     descriptor={firstDescriptor}
-                    titleTailNumChars={titleTailNumChars}
+                    titleTailNumChars={customTitleTailNumChars ?? titleTailNumChars}
                     isClickable={!isEmpty(remainingDescriptors)}
                   />
                 </div>
@@ -84,7 +88,7 @@ export const Breadcrumbs = ({
                   <div className={cx('breadcrumb-item')} key={index}>
                     <Breadcrumb
                       descriptor={descriptor}
-                      titleTailNumChars={titleTailNumChars}
+                      titleTailNumChars={customTitleTailNumChars ?? titleTailNumChars}
                       isClickable={isLastClickable || index !== shownDescriptors.length - 1}
                     />
                   </div>

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -26,5 +26,6 @@ export interface BreadcrumbsProps {
   isBackButton?: boolean;
   isLastClickable?: boolean;
   maxShownDescriptors?: number;
+  titleTailNumChars?: number;
   className?: string;
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/b44405e9-d75f-4e12-92b2-1f4a3e8a61e0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `titleTailNumChars` prop to breadcrumbs, allowing customization of title tail length per instance with automatic fallback to default behavior when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->