### PR TITLE
EPMRPP-107962 || Change focus style to focus-visible for checkboxes

### DIFF
--- a/src/components/checkbox/checkbox.module.scss
+++ b/src/components/checkbox/checkbox.module.scss
@@ -88,7 +88,7 @@
     opacity: var(--rp-ui-opacity-default);
     pointer-events: none;
   }
-  &:focus + .control {
+  &:focus-visible + .control {
     border: 2px solid var(--rp-ui-color-primary-focused);
   }
 


### PR DESCRIPTION
## Description
 
Change focus style to focus-visible for checkboxes 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility by improving how focus indicators display on checkboxes during keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->