### PR TITLE
Allow configuring if single item is clickable in breadcrumbs

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.test.tsx
@@ -78,6 +78,13 @@ describe('Breadcrumbs', () => {
     expect(screen.getAllByTestId('breadcrumb')).toHaveLength(1);
   });
 
+  it('keeps first breadcrumb clickable when there is one item and isSingleItemClickable=true', () => {
+    render(<Breadcrumbs descriptors={[mockDescriptors[0]]} isSingleItemClickable />);
+
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('breadcrumb')).toHaveLength(1);
+  });
+
   it('shows correct hidden breadcrumbs content', () => {
     render(<Breadcrumbs descriptors={mockDescriptors} />);
     expect(screen.queryByTestId('hidden-breadcrumbs-content')).not.toBeInTheDocument();

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -21,6 +21,7 @@ export const Breadcrumbs = ({
   tree,
   isBackButton = false,
   isLastClickable = false,
+  isSingleItemClickable = false,
   maxShownDescriptors = DEFAULT_MAX_SHOWN_DESCRIPTORS,
   titleTailNumChars: customTitleTailNumChars,
   className,
@@ -74,7 +75,7 @@ export const Breadcrumbs = ({
                   <Breadcrumb
                     descriptor={firstDescriptor}
                     titleTailNumChars={customTitleTailNumChars ?? titleTailNumChars}
-                    isClickable={!isEmpty(remainingDescriptors)}
+                    isClickable={isSingleItemClickable || !isEmpty(remainingDescriptors)}
                   />
                 </div>
               )}

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -25,6 +25,7 @@ export interface BreadcrumbsProps {
   dataAutomationId?: string;
   isBackButton?: boolean;
   isLastClickable?: boolean;
+  isSingleItemClickable?: boolean;
   maxShownDescriptors?: number;
   titleTailNumChars?: number;
   className?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation now offers configurable control over the first item's clickability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->