### PR TITLE
EPMRPP-9200 || Improve SingleAutocomplete and add mail icon

### DIFF
--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -18,7 +18,7 @@ import { ComponentProps, FocusEvent, KeyboardEvent, ReactNode, Ref } from 'react
 import classNames from 'classnames/bind';
 import { isEmpty } from 'es-toolkit/compat';
 import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
-import { autoUpdate, useFloating } from '@floating-ui/react';
+import { autoUpdate, useFloating, size } from '@floating-ui/react';
 
 import { default as FieldText } from '@/components/fieldText';
 import { DropdownIcon } from '@/components/icons';
@@ -71,6 +71,7 @@ export interface SingleAutocompleteProps<T> {
     changes: StateChangeOptions<T>,
   ) => Partial<StateChangeOptions<T>>;
   useFixedPositioning: boolean;
+  dropdownMatchInputWidth?: boolean;
   getUniqKey?: (item: T) => string;
   customEmptyListMessage?: string;
   customNoMatchesMessage?: string;
@@ -107,6 +108,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
     stateReducer,
     onStateChange,
     useFixedPositioning,
+    dropdownMatchInputWidth = false,
     newItemButtonText = '',
     ...props
   } = componentProps;
@@ -115,6 +117,17 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
     placement: 'bottom-start',
     strategy: useFixedPositioning ? 'fixed' : 'absolute',
     whileElementsMounted: autoUpdate,
+    middleware: dropdownMatchInputWidth
+      ? [
+          size({
+            apply({ rects, elements }) {
+              Object.assign(elements.floating.style, {
+                width: `${rects.reference.width}px`,
+              });
+            },
+          }),
+        ]
+      : [],
   });
 
   const getOptionProps =

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -35,6 +35,7 @@ export { default as HideIcon } from './svg/hide.svg';
 export { default as ImageIcon } from './svg/image.svg';
 export { default as InfoIcon } from './svg/info.svg';
 export { default as JarIcon } from './svg/jar.svg';
+export { default as MailIcon } from './svg/mail.svg';
 export { default as MaximizeIcon } from './svg/maximize.svg';
 export { default as MeatballMenuIcon } from './svg/meatballMenu.svg';
 export { default as MinusIcon } from './svg/minus.svg';

--- a/src/components/icons/svg/mail.svg
+++ b/src/components/icons/svg/mail.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6.4 6H25.6C26.92 6 28 7.125 28 8.5V23.5C28 24.875 26.92 26 25.6 26H6.4C5.08 26 4 24.875 4 23.5V8.5C4 7.125 5.08 6 6.4 6Z" stroke="#A2AAB5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M28 9L17.1094 16.2604C16.4376 16.7083 15.5624 16.7083 14.8906 16.2604L4 9" stroke="#A2AAB5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Description

### SingleAutocomplete update
Added new optional prop `dropdownMatchInputWidth`. When true, the dropdown option list will have the same width as the parent input.

### New svg icon
Added "mail" svg icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable dropdown width option to the autocomplete component, allowing the dropdown to match the input width when enabled.
  * Introduced MailIcon to the icon library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->