### PR TITLE
EPMRPP-104646 || Extract TextPosition to types.ts for Fast Refresh compatibility

### DIFF
--- a/src/components/attachedFile/attachedFile.stories.tsx
+++ b/src/components/attachedFile/attachedFile.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { AttachedFile, TextPosition } from './attachedFile';
+import { AttachedFile } from './attachedFile';
+import { TextPosition } from './types';
 
 const meta: Meta<typeof AttachedFile> = {
   title: 'Data display/AttachedFile',

--- a/src/components/attachedFile/attachedFile.tsx
+++ b/src/components/attachedFile/attachedFile.tsx
@@ -30,14 +30,10 @@ import {
 import { getFileExtension, addMiddleEllipsis } from '@common/utils';
 import { VoidFn } from '@common/types';
 
+import { TextPosition } from './types';
 import styles from './attachedFile.module.scss';
 
 const cx = classNames.bind(styles);
-
-export enum TextPosition {
-  bottom = 'bottom',
-  right = 'right',
-}
 
 export interface AttachedFileProps {
   fileName: string;

--- a/src/components/attachedFile/types.ts
+++ b/src/components/attachedFile/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-export { AttachedFile } from './attachedFile';
-export { TextPosition } from './types';
-export type { AttachedFileProps } from './attachedFile';
+export enum TextPosition {
+  bottom = 'bottom',
+  right = 'right',
+}


### PR DESCRIPTION
## Description

Moved the `TextPosition` enum from `attachedFile.tsx` into a dedicated `types.ts` file to fix the `react-refresh/only-export-components` ESLint warning.

## Why

Fast Refresh requires `.tsx` files to export only React components. Having `TextPosition` enum exported from `attachedFile.tsx` caused a degradation of Fast Refresh to a full page reload during development.

The fix follows the existing pattern used in `systemAlert/types.ts` and `fileDropArea/types.ts`.

## Changes

- `attachedFile/types.ts` — new file, contains `TextPosition` enum
- `attachedFile/attachedFile.tsx` — imports `TextPosition` from `./types` instead of defining it; no longer exports non-component values
- `attachedFile/index.ts` — re-exports `TextPosition` from `./types` directly
- `attachedFile/attachedFile.stories.tsx` — updated import path for `TextPosition`

Public API is unchanged — consumers importing `TextPosition` from `@reportportal/ui-kit` are not affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a new TextPosition option for the AttachedFile component with choices "bottom" and "right" to control label placement.
* **Refactor**
  * Reorganized the AttachedFile module exports to make the new positioning option publicly available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->