### PR TITLE
EPMRPP-106500 || Remove auto close for Error and Warning system alerts

### DIFF
--- a/src/components/systemAlert/systemAlert.test.tsx
+++ b/src/components/systemAlert/systemAlert.test.tsx
@@ -168,19 +168,24 @@ describe('SystemAlert Component', () => {
       expect(handleClose).toHaveBeenCalledTimes(1);
     });
 
-    it('auto-closes with longer duration for error alert', () => {
+    it('does not auto-close for error alert (user must close)', () => {
       const handleClose = vi.fn();
       render(
         <SystemAlert title="Error Alert" onClose={handleClose} type={SystemAlertType.ERROR} />,
       );
 
+      vi.advanceTimersByTime(10000);
       expect(handleClose).not.toHaveBeenCalled();
+    });
 
-      vi.advanceTimersByTime(6999);
+    it('does not auto-close for warning alert (user must close)', () => {
+      const handleClose = vi.fn();
+      render(
+        <SystemAlert title="Warning Alert" onClose={handleClose} type={SystemAlertType.WARNING} />,
+      );
+
+      vi.advanceTimersByTime(10000);
       expect(handleClose).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(1);
-      expect(handleClose).toHaveBeenCalledTimes(1);
     });
 
     it('auto-closes with custom duration when provided', () => {

--- a/src/components/systemAlert/systemAlert.tsx
+++ b/src/components/systemAlert/systemAlert.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames/bind';
 import { CloseIcon, ErrorIcon, InfoIcon, SuccessIcon } from '@components/icons';
 
 const cx = classNames.bind(styles);
-const ERROR_DURATION = 7000;
 const DEFAULT_DURATION = 4000;
 
 export const SystemAlert: FC<SystemAlertProps> = ({
@@ -18,7 +17,6 @@ export const SystemAlert: FC<SystemAlertProps> = ({
   className,
   dataAutomationId,
 }): ReactElement => {
-  const adjustedDuration = type === SystemAlertType.ERROR ? ERROR_DURATION : duration;
   const [systemTitle, setSystemTitle] = useState('');
   const refSystemAlert = useRef<HTMLDivElement>(null);
 
@@ -31,12 +29,13 @@ export const SystemAlert: FC<SystemAlertProps> = ({
   }, [title]);
 
   useEffect(() => {
+    if ([SystemAlertType.WARNING, SystemAlertType.ERROR].includes(type)) return;
     const timer = setTimeout(() => {
       onClose();
-    }, adjustedDuration);
+    }, duration);
 
     return () => clearTimeout(timer);
-  }, [adjustedDuration, onClose]);
+  }, [type, duration, onClose]);
 
   const getIcon = (): ReactElement | null => {
     switch (type) {


### PR DESCRIPTION
## Changes
1. Removed auto close for `Error` and `Warning` system alerts (requested by designers)

## Links
[EPMRPP-106500](https://jiraeu.epam.com/browse/EPMRPP-106500)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error and warning alerts no longer automatically close; users must manually dismiss these alert types.

* **Tests**
  * Updated test suite to verify auto-close behavior is correctly skipped for error and warning alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->