### PR TITLE
EPMRPP-113652 || Add z-index prop for the BulkPanel

### DIFF
--- a/src/components/bulkPanel/bulkPanel.tsx
+++ b/src/components/bulkPanel/bulkPanel.tsx
@@ -43,6 +43,7 @@ export const BulkPanel = ({
   infoMessage,
   className,
   portalRoot,
+  zIndex = 2,
   onRemoveItem,
   onClearSelection,
 }: BulkPanelProps) => {
@@ -192,6 +193,7 @@ export const BulkPanel = ({
       className={cx('bulk-panel', { expanded: isExpanded }, className)}
       role="region"
       aria-label="Bulk actions panel"
+      style={isExpanded ? { zIndex } : undefined}
     >
       <div className={cx('panel-content', { expanded: isExpanded })} ref={panelContentRef}>
         <div className={cx('header')}>

--- a/src/components/bulkPanel/types.ts
+++ b/src/components/bulkPanel/types.ts
@@ -44,6 +44,7 @@ export interface BulkPanelProps {
   infoMessage?: ReactNode;
   className?: string;
   portalRoot?: Element;
+  zIndex?: number;
   onRemoveItem: (id: string | number) => void;
   onClearSelection: () => void;
 }


### PR DESCRIPTION
1. Added `zIndex` prop similar to the `Modal` component to manage expanded Bulk Panel position  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Bulk panel visual layering is now customizable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->