### PR TITLE
EPMRPP-111117 || Impossible to select options in QG dropdown

### DIFF
--- a/src/components/dropdown/dropdownOption/dropdownOption.tsx
+++ b/src/components/dropdown/dropdownOption/dropdownOption.tsx
@@ -20,14 +20,16 @@ export const DropdownOption: FC<DropdownOptionProps> = forwardRef(
       depth = 0,
       hasChildren = false,
     } = props;
+
     const onChangeHandler: MouseEventHandler<HTMLDivElement | HTMLInputElement> = (e) => {
+      const target = e.target as HTMLElement;
       if (
-        e.target instanceof HTMLDivElement ||
-        e.target instanceof HTMLInputElement ||
-        e.target instanceof HTMLSpanElement
+        target.closest('label') &&
+        !(target instanceof HTMLInputElement || target instanceof HTMLDivElement)
       ) {
-        onChange?.(value);
+        return;
       }
+      onChange?.(value);
     };
 
     return (

--- a/src/components/dropdown/dropdownOption/dropdownOption.tsx
+++ b/src/components/dropdown/dropdownOption/dropdownOption.tsx
@@ -21,7 +21,11 @@ export const DropdownOption: FC<DropdownOptionProps> = forwardRef(
       hasChildren = false,
     } = props;
     const onChangeHandler: MouseEventHandler<HTMLDivElement | HTMLInputElement> = (e) => {
-      if (e.target instanceof HTMLDivElement || e.target instanceof HTMLInputElement) {
+      if (
+        e.target instanceof HTMLDivElement ||
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLSpanElement
+      ) {
         onChange?.(value);
       }
     };


### PR DESCRIPTION
## Description
       The Checkbox renders a <label> wrapping an <input> and a visual <span>.
       Clicking the visual <span> fires two events that both bubble here:
       1. The real span click (target = span)
       2. A synthetic input click automatically fired by the browser for the label's control
       Skip the first (non-input) event so onChange is called only once.

## Visuals

before:

https://github.com/user-attachments/assets/c703e898-c129-44f3-a374-0615f9abddb6

after: 

https://github.com/user-attachments/assets/d00cf532-f79d-4d59-ac4e-fcd667a0984e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental dropdown selection by ensuring option changes only trigger when clicks originate from appropriate elements (inputs, labels or option content), avoiding unintended onChange calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->