### PR TITLE
EPMRPP-103723 || Add radioGroup export

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,7 +23,7 @@ export { Modal } from './modal';
 export { MultipleAutocomplete } from './autocompletes/multipleAutocomplete';
 export { Pagination } from './pagination';
 export { Popover } from './popover';
-export { Radio } from './radio';
+export { Radio, RadioGroup } from './radio';
 export { SegmentedControl } from './segmentedControl';
 export { Selection } from './selection';
 export { SpinLoader } from './spinLoader';

--- a/src/components/radio/index.ts
+++ b/src/components/radio/index.ts
@@ -1,7 +1,8 @@
-import { Radio, RadioProps } from './radio.js';
+import { Radio, RadioProps } from './radio';
+import { RadioGroup, RadioGroupProps } from './radioGroup';
 
-export { Radio };
+export { Radio, RadioGroup };
 
-export type { RadioProps };
+export type { RadioProps, RadioGroupProps };
 
 export default Radio;

--- a/src/components/radio/radioGroup.tsx
+++ b/src/components/radio/radioGroup.tsx
@@ -2,7 +2,7 @@ import { FC, ReactElement } from 'react';
 import { Radio, RadioProps } from './index';
 import { RadioOption } from './radio';
 
-interface RadioGroupProps extends Omit<RadioProps, 'option'> {
+export interface RadioGroupProps extends Omit<RadioProps, 'option'> {
   options: RadioOption[];
 }
 


### PR DESCRIPTION

EPMRPP-103723 || Migrate RadioGroup to ui-kit
[[UI] Remove stale RadioGroup and SystemMessage in favor of ui-kit version](https://jiraeu.epam.com/browse/EPMRPP-103723)

- add RadioGroup export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the component library's public API to include `RadioGroup` component and type definitions, making it available for integration into applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->