### PR TITLE
EPMRPP-113594: Fix close icon overflow in notification popup

### DIFF
--- a/src/components/systemAlert/systemAlert.module.scss
+++ b/src/components/systemAlert/systemAlert.module.scss
@@ -54,6 +54,7 @@
       font-weight: var(--rp-ui-base-fw-semi-bold);
       display: -webkit-box;
       max-width: 100%;
+      margin: 0;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       overflow: hidden;

--- a/src/components/systemAlert/systemAlert.module.scss
+++ b/src/components/systemAlert/systemAlert.module.scss
@@ -3,7 +3,8 @@
 .system-alert {
   display: flex;
   box-sizing: border-box;
-  width: 600px;
+  min-width: 100%;
+  max-width: 600px;
   padding: 16px;
   gap: 16px;
   border-radius: 16px;
@@ -44,6 +45,7 @@
     gap: 16px;
     flex-direction: column;
     flex: 1;
+    min-width: 0;
 
     .title {
       text-align: start;
@@ -55,6 +57,7 @@
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       overflow: hidden;
+      overflow-wrap: anywhere;
 
       &--white {
         color: var(--rp-ui-base-bg-000);

--- a/src/components/systemAlert/systemAlert.test.tsx
+++ b/src/components/systemAlert/systemAlert.test.tsx
@@ -231,6 +231,26 @@ describe('SystemAlert Component', () => {
     });
   });
 
+  describe('Long text overflow', () => {
+    it('renders close button and title for long unbroken text', () => {
+      const handleClose = vi.fn();
+      const longUnbrokenTitle = 'A'.repeat(500);
+      const { container } = render(
+        <SystemAlert
+          title={longUnbrokenTitle}
+          onClose={handleClose}
+          type={SystemAlertType.ERROR}
+        />,
+      );
+
+      const alertElement = container.querySelector('[class*="system-alert"]');
+      const closeButton = screen.getByRole('button', { name: /close system alert/i });
+
+      expect(alertElement).toContainElement(closeButton);
+      expect(screen.getByText(longUnbrokenTitle)).toBeInTheDocument();
+    });
+  });
+
   describe('Accessibility', () => {
     it('has accessible close button with aria-label', () => {
       const handleClose = vi.fn();

--- a/src/components/systemAlert/systemAlert.tsx
+++ b/src/components/systemAlert/systemAlert.tsx
@@ -18,14 +18,33 @@ export const SystemAlert: FC<SystemAlertProps> = ({
   dataAutomationId,
 }): ReactElement => {
   const [systemTitle, setSystemTitle] = useState('');
-  const refSystemAlert = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
-    const { offsetHeight, scrollHeight } = refSystemAlert?.current as HTMLDivElement;
-
-    if (offsetHeight < scrollHeight) {
-      setSystemTitle(title);
+    const el = titleRef.current;
+    if (!el) {
+      return;
     }
+
+    const checkOverflow = () => {
+      const { offsetHeight, scrollHeight } = el;
+      if (offsetHeight < scrollHeight) {
+        setSystemTitle(title);
+      } else {
+        setSystemTitle('');
+      }
+    };
+
+    checkOverflow();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(checkOverflow);
+    resizeObserver.observe(el);
+
+    return () => resizeObserver.disconnect();
   }, [title]);
 
   useEffect(() => {
@@ -54,12 +73,15 @@ export const SystemAlert: FC<SystemAlertProps> = ({
   return (
     <div
       className={cx('system-alert', type, className, `system-alert--${typographyColor}`)}
-      title={systemTitle}
       data-automation-id={dataAutomationId}
     >
       <div className={cx('icon-wrapper')}>{getIcon()}</div>
       <div className={cx('content-wrapper')}>
-        <h2 ref={refSystemAlert} className={cx('title', `title--${typographyColor}`)}>
+        <h2
+          ref={titleRef}
+          className={cx('title', `title--${typographyColor}`)}
+          title={systemTitle || undefined}
+        >
           {title}
         </h2>
       </div>


### PR DESCRIPTION
**error**
<img width="350" height="400" alt="error long text" src="https://github.com/user-attachments/assets/3e6b9bdb-c115-4665-8026-869cb3694c49" />
<img width="350" height="400" alt="error no space" src="https://github.com/user-attachments/assets/93b4ce4b-e3d9-4420-bec7-3771810fb21c" />

**small screen**
<img width="450" height="376" alt="mobile" src="https://github.com/user-attachments/assets/4fc580e4-ca51-49f6-a322-46744cd2aac0" />


**warning**
<img width="350" height="400" alt="warning long text" src="https://github.com/user-attachments/assets/3c2dfc50-7d86-49e9-8806-fc1ab44f631c" />
<img width="350" height="400" alt="warning no space" src="https://github.com/user-attachments/assets/a791da91-9b40-4cbe-92c1-7aa8c6470525" />

**success**
<img width="350" height="400" alt="success long text" src="https://github.com/user-attachments/assets/2b1ed618-8f42-43c3-aaff-08484e1b28a6" />
<img width="350" height="400" alt="success no space" src="https://github.com/user-attachments/assets/024d012e-50fe-499d-a9c3-8c029eb6f04d" />

**info**
<img width="350" height="400" alt="info long text" src="https://github.com/user-attachments/assets/38d301a4-dfc0-4c89-ad45-4f1859f48211" />
<img width="350" height="400" alt="info no space" src="https://github.com/user-attachments/assets/5ab0435f-b59a-4c5e-b739-4d1425a87632" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System alert now uses responsive min/max width to prevent overflow on varied screen sizes.
  * Alert content better handles long titles: improved wrapping/truncation to avoid layout shifts on narrow containers.
  * Tooltip/hover title only appears when the visible heading is truncated and is recalculated on resize for accurate display.

* **Tests**
  * Added test coverage for rendering very long unbroken alert titles and presence/function of the alert close control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->