### PR TITLE
EPMRPP-113689/Replace Breadcrumbs component from componentsLibrary with component from ui-kit

### DIFF
--- a/src/components/breadcrumbs/breadcrumb/breadcrumb.module.scss
+++ b/src/components/breadcrumbs/breadcrumb/breadcrumb.module.scss
@@ -7,6 +7,10 @@
 .link {
   text-decoration: none;
   outline: none;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
 }
 
 .breadcrumb-text {

--- a/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames/bind';
-import { BreadcrumbDescriptor } from '../types';
+import { BreadcrumbDescriptor, LinkComponentType } from '../types';
 import { useBreadcrumbsContext } from '../breadcrumbsProvider/hooks';
 import styles from './breadcrumb.module.scss';
 
@@ -12,6 +12,60 @@ interface BreadcrumbProps {
   isClickable?: boolean;
   variant?: 'default' | 'dark';
 }
+
+interface GetCrumbContent {
+  ({
+    LinkComponent,
+    link,
+    onClick,
+    isClickable,
+    breadcrumbContent,
+  }: {
+    LinkComponent?: LinkComponentType;
+    link?: object | string;
+    onClick?: () => void;
+    isClickable?: boolean;
+    breadcrumbContent: React.ReactNode;
+  }): React.ReactNode;
+}
+
+const getCrumbContent: GetCrumbContent = ({
+  LinkComponent,
+  link,
+  onClick,
+  isClickable,
+  breadcrumbContent,
+}) => {
+  if (!isClickable) {
+    return breadcrumbContent;
+  }
+
+  if (link) {
+    if (LinkComponent) {
+      return (
+        <LinkComponent className={cx('link')} to={link} onClick={onClick}>
+          {breadcrumbContent}
+        </LinkComponent>
+      );
+    }
+
+    return (
+      <a className={cx('link')} href={typeof link === 'string' ? link : '#'} onClick={onClick}>
+        {breadcrumbContent}
+      </a>
+    );
+  }
+
+  if (onClick) {
+    return (
+      <button type="button" className={cx('link')} onClick={onClick}>
+        {breadcrumbContent}
+      </button>
+    );
+  }
+
+  return breadcrumbContent;
+};
 
 export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   titleTailNumChars = 8,
@@ -47,23 +101,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
       title={breadcrumbTitle || undefined}
       data-testid="breadcrumb"
     >
-      {isClickable ? (
-        LinkComponent && link ? (
-          <LinkComponent className={cx('link')} to={link} onClick={onClick}>
-            {breadcrumbContent}
-          </LinkComponent>
-        ) : link ? (
-          <a className={cx('link')} href={typeof link === 'string' ? link : '#'} onClick={onClick}>
-            {breadcrumbContent}
-          </a>
-        ) : (
-          <button type="button" className={cx('link')} onClick={onClick}>
-            {breadcrumbContent}
-          </button>
-        )
-      ) : (
-        breadcrumbContent
-      )}
+      {getCrumbContent({ LinkComponent, link, onClick, isClickable, breadcrumbContent })}
     </div>
   );
 };

--- a/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb/breadcrumb.tsx
@@ -69,7 +69,7 @@ const getCrumbContent: GetCrumbContent = ({
 
 export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   titleTailNumChars = 8,
-  descriptor: { title, link, onClick },
+  descriptor: { title, link, onClick, className },
   isClickable = true,
   variant = 'default',
 }) => {
@@ -90,7 +90,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
   }, [title, titleTailNumChars]);
 
   const breadcrumbContent = (
-    <div ref={ref} className={cx('breadcrumb-text', variant)}>
+    <div ref={ref} className={cx('breadcrumb-text', variant, className)}>
       {title}
     </div>
   );

--- a/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -193,8 +193,7 @@ const treeData: TreeDescriptor[] = [
           },
           {
             title: 'Item B2',
-            link: { pathname: '/categories/item-b2' },
-            onClick: () => console.log('Item B2 clicked'),
+            className: 'active-color', // Example of custom class for styling
           },
         ],
       },

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 
 export interface BreadcrumbDescriptor {
+  className?: string;
   title: string | ReactNode;
   link?: object | string;
   onClick?: () => void;

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -7,7 +7,8 @@ export interface BreadcrumbDescriptor {
 }
 
 export interface TreeDescriptor extends BreadcrumbDescriptor {
-  link: object | string;
+  link?: object | string;
+  onClick?: () => void;
   children?: TreeDescriptor[];
 }
 

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -8,8 +8,6 @@ export interface BreadcrumbDescriptor {
 }
 
 export interface TreeDescriptor extends BreadcrumbDescriptor {
-  link?: object | string;
-  onClick?: () => void;
   children?: TreeDescriptor[];
 }
 


### PR DESCRIPTION
[EPMRPP-113689/Replace Breadcrumbs component from componentsLibrary with component from ui-kit](https://jiraeu.epam.com/browse/EPMRPP-113689)

[fix button styles](https://github.com/reportportal/ui-kit/commit/1b596411480a4310f69f469c7a40cfe5e02fe3cb)
Before:
<img width="719" height="544" alt="image" src="https://github.com/user-attachments/assets/3850a603-b279-4766-bad1-d4ae9ab58ba1" />


After:
<img width="2416" height="565" alt="image" src="https://github.com/user-attachments/assets/9d54843f-59ec-4b3e-a16e-aae755a61706" />


[handle case when no link and no onClick](https://github.com/reportportal/ui-kit/commit/5d8451d4369b0fd7056ee3ba184440c1d4551fcf)
Before:
<img width="2540" height="657" alt="image" src="https://github.com/user-attachments/assets/82f5b51c-5cde-4102-b615-117bb6af3dae" />


After:
<img width="2443" height="603" alt="image" src="https://github.com/user-attachments/assets/3b7042b1-d416-43c1-bbe2-98c3a18e0d6b" />


[feat: add classname support](https://github.com/reportportal/ui-kit/commit/395dc9572563a0311938d308f670e4b1c0d2dbe8):
After:
<img width="2636" height="601" alt="image" src="https://github.com/user-attachments/assets/56642176-30f7-4eeb-ab46-01ccbe61cefe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breadcrumbs accept an optional custom className for flexible per-item styling.
  * Improved breadcrumb rendering for interactive items: clearer behavior for links, buttons, and non-clickable items.

* **Style**
  * Breadcrumb link visuals reset to remove default button/link chrome and use pointer cursor for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->