### PR TITLE
EPMRPP-113580 || Add ellipsis behavior to the primitive table cells

### DIFF
--- a/src/components/table/table.module.scss
+++ b/src/components/table/table.module.scss
@@ -283,6 +283,15 @@ $EXPANDABLE_CHECKBOX_Z_INDEX: 10;
   }
 }
 
+.primitive-cell-text {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .table-header-cell,
 .table-cell {
   font-family: var(--rp-ui-base-font-family);

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,4 +1,13 @@
-import { useMemo, FC, useEffect, useRef, useState, useCallback, useLayoutEffect } from 'react';
+import {
+  useMemo,
+  FC,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  useLayoutEffect,
+  ReactNode,
+} from 'react';
 import { Resizable } from 'react-resizable';
 import { isEmpty } from 'es-toolkit/compat';
 import styles from './table.module.scss';
@@ -28,8 +37,42 @@ import {
 } from './hooks';
 import { ResizeHandle } from './resizeHandle';
 import { GradientOverlay } from './gradientOverlay';
+import { useEllipsisTitle } from '@common/hooks';
 
 const cx = classNames.bind(styles);
+
+const TablePrimitiveCell: FC<{ value: string | number; expanded: boolean }> = ({
+  value,
+  expanded,
+}) => {
+  const { ref, title } = useEllipsisTitle(expanded ? undefined : value);
+  const text = String(value);
+  return (
+    <span ref={ref} title={expanded ? undefined : title} className={cx('primitive-cell-text')}>
+      {text}
+    </span>
+  );
+};
+
+const renderTableBodyCellContent = (raw: unknown, expanded: boolean): ReactNode => {
+  if (raw == null) {
+    return null;
+  }
+  let node: ReactNode;
+  if (typeof raw === 'object' && ('component' in raw || 'content' in raw)) {
+    const cell = raw as { component?: ReactNode; content?: string | number };
+    node = cell.component || cell.content;
+    if (node == null) {
+      return null;
+    }
+  } else {
+    node = raw as ReactNode;
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return <TablePrimitiveCell value={node} expanded={expanded} />;
+  }
+  return node;
+};
 
 const ColumnHeaderText: FC<{ column: PrimaryColumn | FixedColumn }> = ({ column }) => {
   const spanRef = useRef<HTMLSpanElement>(null);
@@ -964,7 +1007,7 @@ export const Table: FC<TableComponentProps> = ({
                         isCheckboxOutside,
                       )}
                     >
-                      {item[column.key].component || item[column.key].content || item[column.key]}
+                      {renderTableBodyCellContent(item[column.key], isExpanded)}
                     </div>
                   );
                 })}
@@ -991,7 +1034,7 @@ export const Table: FC<TableComponentProps> = ({
                         isCheckboxOutside,
                       )}
                     >
-                      {item[column.key].component || item[column.key].content || item[column.key]}
+                      {renderTableBodyCellContent(item[column.key], isExpanded)}
                     </div>
                   );
                 })}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -61,7 +61,7 @@ const renderTableBodyCellContent = (raw: unknown, expanded: boolean): ReactNode 
   let node: ReactNode;
   if (typeof raw === 'object' && ('component' in raw || 'content' in raw)) {
     const cell = raw as { component?: ReactNode; content?: string | number };
-    node = cell.component || cell.content;
+    node = cell.component ?? cell.content;
     if (node == null) {
       return null;
     }

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -48,7 +48,11 @@ const TablePrimitiveCell: FC<{ value: string | number; expanded: boolean }> = ({
   const { ref, title } = useEllipsisTitle(expanded ? undefined : value);
   const text = String(value);
   return (
-    <span ref={ref} title={expanded ? undefined : title} className={cx('primitive-cell-text')}>
+    <span
+      ref={ref}
+      title={expanded ? undefined : title}
+      className={cx({ 'primitive-cell-text': !expanded })}
+    >
       {text}
     </span>
   );


### PR DESCRIPTION
## Summary

Add the possibility to automatically shrink text with ellipsis if it length longer than cell width.

## Visuals


https://github.com/user-attachments/assets/e8856526-b330-4eb0-9f94-b6de6dbcdf31



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Table cells now truncate long text with an ellipsis for cleaner layouts.
  * Primitive cell values (strings/numbers) render consistently and suppress redundant tooltips when a row is expanded.
* **Bug Fixes**
  * Empty or missing cell values are handled more predictably, avoiding accidental rendering of raw objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->