### PR TITLE
EPMRPP-113738 || Fix FieldNumber out-of-bounds value handling

### DIFF
--- a/src/components/fieldNumber/fieldNumber.test.tsx
+++ b/src/components/fieldNumber/fieldNumber.test.tsx
@@ -288,6 +288,16 @@ describe('FieldNumber Component', () => {
       expect(handleChange).toHaveBeenCalledWith(5);
     });
 
+    it('decrements from a value above max after clamping on first click', () => {
+      const handleChange = vi.fn();
+      render(<FieldNumber onChange={handleChange} value={999999911199} min={0} max={999999999} />);
+      const minusButton = screen.getByText('-').closest('button');
+      if (minusButton) {
+        fireEvent.click(minusButton);
+      }
+      expect(handleChange).toHaveBeenCalledWith(999999998);
+    });
+
     it('normalizes value to min on blur when below min', () => {
       const handleChange = vi.fn();
       render(<FieldNumber onChange={handleChange} value={5} min={10} max={20} />);

--- a/src/components/fieldNumber/fieldNumber.tsx
+++ b/src/components/fieldNumber/fieldNumber.tsx
@@ -54,31 +54,33 @@ export const FieldNumber = ({
   const inputId = useId();
 
   const normalizeValue = (val: number): number => {
+    if (Number.isNaN(val)) return min;
+    if (val === Number.POSITIVE_INFINITY) return max;
+    if (val === Number.NEGATIVE_INFINITY) return min;
     if (val < min) return min;
     if (val > max) return max;
     return val;
   };
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    let newValue: FieldNumberValue = event.target.value.replace(/^0(?=\d+|^\d)/g, '');
+    const newValue: FieldNumberValue = event.target.value.replace(/^0(?=\d+|^\d)/g, '');
     if (newValue === '') {
       onChange('');
       return;
     }
-    newValue = +newValue;
-    onChange(newValue);
+    onChange(+newValue);
   };
 
   const handleBlur: FocusEventHandler<HTMLInputElement> = (event) => {
+    if (onBlur) {
+      onBlur(event);
+    }
+
     const numValue = +event.currentTarget.value;
     const normalizedValue = normalizeValue(numValue);
 
     if (normalizedValue !== numValue) {
       onChange(normalizedValue);
-    }
-
-    if (onBlur) {
-      onBlur(event);
     }
   };
 
@@ -98,13 +100,15 @@ export const FieldNumber = ({
     }
   };
   const handleDecrease = () => {
-    const newValue = +value - 1;
+    const clamped = normalizeValue(+value);
+    const newValue = clamped - 1;
     if (newValue >= min && newValue <= max) {
       onChange(newValue);
     }
   };
   const handleIncrease = () => {
-    const newValue = +value + 1;
+    const clamped = normalizeValue(+value);
+    const newValue = clamped + 1;
     if (newValue >= min && newValue <= max) {
       onChange(newValue);
     }


### PR DESCRIPTION
## Fix FieldNumber out-of-bounds value handling

### Changes

**`normalizeValue`** — added guards for `NaN`, `+Infinity`, and `-Infinity`.

**`handleBlur`** — `onBlur(event)` is now called before `onChange(normalizedValue)`, so that redux-form's `onBlur` does not overwrite the normalized value written by `onChange`.

**`handleDecrease` / `handleIncrease`** — clamp the current value to `[min, max]` before applying `±1`. Previously, if `value` exceeded `max`, the step produced a result still above `max` and the `newValue <= max` guard silently blocked the call.

**Tests** — added a test covering decrement from a value above `max`.

### Visuals

**Before**


https://github.com/user-attachments/assets/58fbdeb3-202c-4d1f-a49b-58dd742a79f1


**After**

https://github.com/user-attachments/assets/91914844-cfae-4741-98bc-cc251799eb8c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the fieldNumber component to properly handle invalid and out-of-bounds numeric values, including NaN and Infinity cases.
  * Corrected the behavior of decrease and increase button interactions when the current value exceeds minimum or maximum constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->