### PR TITLE
EPMRPP-114186 || Allow configuring Popover's transition duration and disabling focus props

### DIFF
--- a/src/components/popover/README.md
+++ b/src/components/popover/README.md
@@ -2,17 +2,22 @@
 
 ### Popover props:
 
-- **className**: _string_, optional, default = ''
 - **content**: _node_, required
 - **children**: _node_, required
 - **placement**: _string_ (Floating UI Placement), optional, default = 'bottom'
 - **fallbackPlacements**: _string_ (Floating UI Placement), optional, default = 'bottom'
+- **className**: _string_, optional, default = ''
 - **title**: _string_, optional, default = ''
 - **arrowOffset**: _number_, optional, default = 16
 - **safeZone**: _number_, optional, default = 4
 - **arrowColor**: _string_, optional, default = 'white'
 - **dataAutomationId**: _string_, optional, default = ''
+- **strategy**: _string_ (Floating UI Strategy), optional, default = 'absolute'
+- **transitionDuration**: _number_ or _object_ ({ open?: number, close?: number }), optional, default = 0
+- **isCentered**: _bool_, optional, default = true
+- **isFocusDisabled**: _bool_, optional, default = false
 - **isOpened**: _bool_, optional, default = false
+- **shouldUsePortal**: _bool_, optional, default = false
 - **setIsOpened**: _func_, optional, default = undefined
 
 ### Size

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -28,6 +28,7 @@ import {
   useInteractions,
   FloatingFocusManager,
   FloatingPortal,
+  useTransitionStyles,
   Placement,
   Strategy,
   ElementRects,
@@ -56,9 +57,16 @@ export interface PopoverProps {
   safeZone?: number;
   arrowColor?: string;
   dataAutomationId?: string;
-  isOpened?: boolean;
-  isCentered?: boolean;
   strategy?: Strategy;
+  transitionDuration?:
+    | number
+    | Partial<{
+        open: number;
+        close: number;
+      }>;
+  isCentered?: boolean;
+  isFocusDisabled?: boolean;
+  isOpened?: boolean;
   shouldUsePortal?: boolean;
   setIsOpened?: (isOpened: boolean) => void;
 }
@@ -66,17 +74,19 @@ export interface PopoverProps {
 export const Popover: FC<PopoverProps> = ({
   content,
   children,
-  className,
   placement: initialPlacement = 'bottom',
   fallbackPlacements = allPlacements,
+  className,
   title,
   arrowOffset = ARROW_OFFSET,
   safeZone = 4,
   arrowColor = 'white',
   dataAutomationId,
-  isOpened,
-  isCentered = true,
   strategy: positionStrategy = 'absolute',
+  transitionDuration = 0,
+  isCentered = true,
+  isFocusDisabled = false,
+  isOpened,
   shouldUsePortal = false,
   setIsOpened,
 }): ReactElement => {
@@ -127,14 +137,23 @@ export const Popover: FC<PopoverProps> = ({
 
   const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role]);
 
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(context, {
+    duration: transitionDuration,
+    initial: { opacity: 0 },
+  });
+
   const renderFloatingElement = () => {
     const floatingElement = (
-      <FloatingFocusManager context={context} modal={false}>
+      <FloatingFocusManager context={context} modal={false} disabled={isFocusDisabled}>
         <div
           className={cx('popover', className)}
           data-automation-id={dataAutomationId}
           ref={refs.setFloating}
-          style={floatingStyles}
+          style={{
+            ...floatingStyles,
+            ...transitionStyles,
+            pointerEvents: isPopoverOpen ? 'auto' : 'none',
+          }}
           {...getFloatingProps()}
         >
           <FloatingArrow
@@ -159,7 +178,7 @@ export const Popover: FC<PopoverProps> = ({
       <div ref={refs.setReference} {...getReferenceProps()} className={cx('popover-wrapper')}>
         {children}
       </div>
-      {isPopoverOpen && renderFloatingElement()}
+      {isMounted && renderFloatingElement()}
     </>
   );
 };


### PR DESCRIPTION
Introduced new props to customize popover behavior:

- `transitionDuration `allows setting the duration of the opening animation (defaults to 0 milliseconds)
- `isFocusDisabled `disables automatic focus management within the popover (enabled by default)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popover gains configurable transition animations for smoother open/close behavior.
  * Optional focus-management control to better support accessibility flows.
  * More flexible placement options including centering and portal-based rendering for improved layout control.
  * Improved animation handling keeps the popover mounted during transitions to prevent visual flicker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->