### PR TITLE
EPMRPP-107457 || 107446 || Fix two bugs

### DIFF
--- a/src/components/autocompletes/hooks/useScrollClose.tsx
+++ b/src/components/autocompletes/hooks/useScrollClose.tsx
@@ -1,0 +1,27 @@
+import { useEffect, type RefObject } from 'react';
+
+interface UseScrollClose {
+  (props: { skip?: boolean; onClose: () => void; menuRef: RefObject<HTMLElement | null> }): void;
+}
+
+export const useScrollClose: UseScrollClose = ({ skip, onClose, menuRef }) => {
+  useEffect(() => {
+    if (skip) {
+      return;
+    }
+
+    const handleScroll = (event: Event) => {
+      if (menuRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      onClose();
+    };
+
+    // Capture phase (true) catches scroll from any ancestor container
+    window.addEventListener('scroll', handleScroll, true);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [skip, onClose, menuRef]);
+};

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.stories.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.stories.tsx
@@ -16,6 +16,11 @@ const OPTIONS_STRINGS: string[] = [
   'Demo Api Tests 1',
   'Demo Api Tests 2',
   'Demo Api Tests 3',
+  'Demo Api Tests 4',
+  'Demo Api Tests 5',
+  'Demo Api Tests 6',
+  'Demo Api Tests 7',
+  'Demo Api Tests 8',
 ];
 
 type WithStorybookProps<T, K> = T & { value: K };
@@ -226,6 +231,56 @@ export const SingleSelectWithMenuPortal: Story<string> = {
         >
           <SingleAutocomplete {...args} />
         </div>
+      </div>
+    );
+  },
+};
+
+export const SingleSelectWithHideByScroll: Story<string> = {
+  args: {
+    ...TEST_DATA_STRINGS,
+    dropdownMatchInputWidth: true,
+    withMenuFlip: true,
+    menuPortalRoot: document.body,
+    isDropdownMode: true,
+  },
+  render: (args) => {
+    return (
+      <div
+        style={{
+          width: '500px',
+          height: '150px',
+          overflow: 'auto',
+          border: '2px dashed #aaa',
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '16px',
+        }}
+      >
+        <div
+          style={{
+            width: '400px',
+          }}
+        >
+          <SingleAutocomplete {...args} />
+        </div>
+
+        <p style={{ marginBottom: '16px', maxWidth: '400px' }}>
+          This is a very long text to enable scrolling. This example demonstrates that the dropdown
+          will close when the user scrolls the page, which is a common UX pattern to prevent the
+          dropdown from being detached from the input. Try scrolling the page to see it in action.
+          So i need to scroll the page to see the effect of the dropdown closing when the user
+          scrolls. This is a very long text to enable scrolling. This example demonstrates that the
+          dropdown will close when the user scrolls the page, which is a common UX pattern to
+          prevent the dropdown from being detached from the input. Try scrolling the page to see it
+          in action. This is a very long text to enable scrolling. This example demonstrates that
+          the dropdown will close when the user scrolls the page, which is a common UX pattern to
+          prevent the dropdown from being detached from the input. Try scrolling the page to see it
+          in action. This is a very long text to enable scrolling. This example demonstrates that
+          the dropdown will close when the user scrolls the page, which is a common UX pattern to
+          prevent the dropdown from being detached from the input. Try scrolling the page to see it
+          in action.
+        </p>
       </div>
     );
   },

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -23,6 +23,7 @@ import {
   useState,
   useCallback,
   useMemo,
+  useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames/bind';
@@ -37,6 +38,7 @@ import { AutocompleteMenu } from '../common/autocompleteMenu';
 import { ENTER_KEY_NAME, TAB_KEY_NAME } from '../constants';
 import { usePreventInitialScroll } from '../hooks/usePreventInitialScroll';
 import { useResizeClose } from '../hooks/useResizeClose';
+import { useScrollClose } from '../hooks/useScrollClose';
 import { GetItemPropsT } from '../types';
 
 import styles from './singleAutocomplete.module.scss';
@@ -150,8 +152,12 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
   } = componentProps;
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const closeMenuRef = useRef<(() => void) | null>(null);
+  const handleScrollClose = useCallback(() => closeMenuRef.current?.(), []);
+
   const shouldSkipPortalActions = !isMenuOpen || !menuPortalRoot;
   const strategy = menuPortalRoot || useFixedPositioning ? 'fixed' : 'absolute';
+  const shouldSkipScrollClose = !isMenuOpen || strategy === 'absolute';
 
   const middleware = useMemo(
     () => [
@@ -170,6 +176,11 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
 
   usePreventInitialScroll({ skip: shouldSkipPortalActions });
   useResizeClose({ skip: shouldSkipPortalActions, reference: refs.reference });
+  useScrollClose({
+    skip: shouldSkipScrollClose,
+    onClose: handleScrollClose,
+    menuRef: refs.floating,
+  });
 
   const getOptionProps =
     (
@@ -223,6 +234,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
         setHighlightedIndex,
         toggleMenu,
         openMenu,
+        closeMenu,
         isOpen,
         inputValue,
         highlightedIndex,
@@ -237,6 +249,10 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
             return rootProps.ref(node);
           },
         };
+
+        if (!closeMenuRef.current) {
+          closeMenuRef.current = closeMenu;
+        }
 
         const downshiftValue = inputValue ?? '';
 


### PR DESCRIPTION
EPMRPP-107457 || 107446 || Fix two bugs

https://jiraeu.epam.com/browse/EPMRPP-107457
https://jiraeu.epam.com/browse/EPMRPP-107446

How to test:
- run storybook
- navigate to http://localhost:6006/?path=/story/controls-autocompletes-singleautocomplete--single-select-with-hide-by-scroll
- ensure:
  - scrolling inside component doesn't close menu
  - scrolling outside component closes menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Autocomplete dropdown menus now automatically close when you scroll outside of them, preventing menus from remaining open during page navigation and reducing visual clutter. This enhancement provides a more intuitive user experience when working with autocomplete fields in scrollable page sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->