### PR TITLE
EPMRPP-86399 || 86399 || Value is cut in Number field for "Percent" rule

### DIFF
--- a/src/components/fieldNumber/constants.ts
+++ b/src/components/fieldNumber/constants.ts
@@ -1,7 +1,9 @@
 import { KeyCodes } from '@common/constants/keyCodes';
 
 export const DEFAULT_WIDTH_CH = 5;
-export const MAX_WIDTH_CH = 16;
+// Extra ch offset to prevent first character clipping in Safari
+export const SAFARI_CLIP_FIX_CH = 0.4;
+export const MAX_WIDTH_CH = 16 + SAFARI_CLIP_FIX_CH;
 
 export const ALLOWED_KEY_CODES = [
   KeyCodes.TAB_KEY_CODE,

--- a/src/components/fieldNumber/fieldNumber.test.tsx
+++ b/src/components/fieldNumber/fieldNumber.test.tsx
@@ -4,7 +4,7 @@ import { userEvent } from '@testing-library/user-event';
 import { KeyCodes } from '@common/constants/keyCodes';
 import DefaultExport, { FieldNumber as NamedExport } from './index';
 import { FieldNumber } from './fieldNumber';
-import { MAX_WIDTH_CH, DEFAULT_WIDTH_CH } from './constants';
+import { MAX_WIDTH_CH, DEFAULT_WIDTH_CH, SAFARI_CLIP_FIX_CH } from './constants';
 
 vi.mock('@components/icons', () => ({
   PlusIcon: () => <span>+</span>,
@@ -349,9 +349,14 @@ describe('FieldNumber Component', () => {
     });
 
     it('dynamically adjusts input width based on value length', () => {
-      render(<FieldNumber onChange={() => {}} value={12345} />);
+      const value = '12345';
+
+      render(<FieldNumber onChange={vi.fn()} value={value} />);
+
       const inputField = screen.getByRole('spinbutton');
-      expect(inputField).toHaveStyle({ width: '5ch' });
+      const expectedWidth = `${value.length + SAFARI_CLIP_FIX_CH}ch`;
+
+      expect(inputField).toHaveStyle({ width: expectedWidth });
     });
 
     it('applies postfix only when value is present', () => {

--- a/src/components/fieldNumber/fieldNumber.tsx
+++ b/src/components/fieldNumber/fieldNumber.tsx
@@ -13,7 +13,12 @@ import { KeyCodes } from '@common/constants/keyCodes';
 import { BaseIconButton } from '@components/baseIconButton';
 import { PlusIcon, MinusIcon } from '@components/icons';
 import { FieldLabel } from '@components/fieldLabel';
-import { DEFAULT_WIDTH_CH, ALLOWED_KEY_CODES, MAX_WIDTH_CH } from './constants.js';
+import {
+  DEFAULT_WIDTH_CH,
+  ALLOWED_KEY_CODES,
+  MAX_WIDTH_CH,
+  SAFARI_CLIP_FIX_CH,
+} from './constants.js';
 import styles from './fieldNumber.module.scss';
 
 const cx = classNames.bind(styles);
@@ -115,7 +120,7 @@ export const FieldNumber = ({
   };
   const placeholderValue = placeholder + postfix;
   const inputWidth = useMemo(() => {
-    let width = (String(value) || placeholderValue).length;
+    let width = (String(value) || placeholderValue).length + SAFARI_CLIP_FIX_CH;
     if (postfix && !value) {
       width += 1;
     }

--- a/src/components/fieldNumber/fieldNumber.tsx
+++ b/src/components/fieldNumber/fieldNumber.tsx
@@ -120,12 +120,20 @@ export const FieldNumber = ({
   };
   const placeholderValue = placeholder + postfix;
   const inputWidth = useMemo(() => {
-    let width = (String(value) || placeholderValue).length + SAFARI_CLIP_FIX_CH;
+    let width = (String(value) || placeholderValue).length;
     if (postfix && !value) {
       width += 1;
     }
 
-    return width > MAX_WIDTH_CH ? `${MAX_WIDTH_CH}ch` : `${width || DEFAULT_WIDTH_CH}ch`;
+    if (!width) {
+      return `${DEFAULT_WIDTH_CH}ch`;
+    }
+
+    if (width > MAX_WIDTH_CH) {
+      return `${MAX_WIDTH_CH}ch`;
+    }
+
+    return `${width + SAFARI_CLIP_FIX_CH}ch`;
   }, [placeholderValue, postfix, value]);
   const handleInputFieldClick: MouseEventHandler<HTMLDivElement> = () => {
     if (inputRef && inputRef.current) {


### PR DESCRIPTION
[EPMRPP-86399 || 86399 || Value is cut in Number field for "Percent" rule](https://jiraeu.epam.com/browse/EPMRPP-86399)

-  add a ch fractional offset

 Safari  measures ch units slightly differently than other  browsers, which can cause the first digit to be clipped.
 
 
<img width="2085" height="1522" alt="image" src="https://github.com/user-attachments/assets/84116a8a-a176-4f01-ad48-87a1f2f64cdb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved text clipping in number input fields on Safari by adjusting input sizing so values display fully.
* **UI Behavior**
  * Number inputs now size more consistently based on value length, improving layout stability when typing or setting values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->