### PR TITLE
EPMRPP-113582 || Treat empty string as selected when it matches an option

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -216,9 +216,17 @@ export const Dropdown: FC<DropdownProps> = ({
     }
     return normalizeSelectedValues(new Set<DropdownValue>(value));
   }, [multiSelect, value, normalizeSelectedValues]);
-  const hasSelectedValue = multiSelect
-    ? Array.isArray(value) && value.length > 0
-    : value || value === false || value === 0;
+  const hasSelectedValue = useMemo(() => {
+    if (multiSelect) {
+      return Array.isArray(value) && value.length > 0;
+    }
+    return (
+      selectableOptions.some((option) => option.value === value) ||
+      value === false ||
+      value === 0 ||
+      Boolean(value)
+    );
+  }, [multiSelect, value, selectableOptions]);
   const shouldShowClearButton = clearable && hasSelectedValue && !disabled;
 
   const handleScrollFrame = useCallback((values: { scrollTop: number }) => {


### PR DESCRIPTION
## Summary

Single-select `Dropdown` used `hasSelectedValue = value || value === false || value === 0`, so a legitimate option with `value: ''` was treated as “no selection”. The label still came from options, but the toggle kept placeholder styling (gray text). `hasSelectedValue` is now derived consistently: match against `selectableOptions` first, then preserve previous behavior for values not present in the list (`false`, `0`, and other truthy values).

## Context

Related defect: **EPMRPP-113582** (LDAP “Password encoder type”: “NO” shown with placeholder color). The LDAP form uses `{ value: '', label: 'NO' }`; this change fixes that class of issues for any consumer without form-level workarounds.


## Visuals

**Before**

<img width="927" height="846" alt="image" src="https://github.com/user-attachments/assets/db440853-8c78-48f0-9d86-3571fd4d8b36" />

**After**

<img width="905" height="839" alt="image" src="https://github.com/user-attachments/assets/9a3a149b-30c3-4cc2-acf7-3829ffec24bf" />
