### PR TITLE
EPMRPP || Popup is cut when it is opened for one item at "All Users" page

### DIFF
--- a/src/components/actionMenu/actionMenu.module.scss
+++ b/src/components/actionMenu/actionMenu.module.scss
@@ -21,6 +21,8 @@
   vertical-align: middle;
 }
 
+// .actions-popover.actions-popover has two-class specificity, same as the old nested rule, 
+// so it beats .popover { padding: 16px } regardless of load order.
 .actions-popover.actions-popover {
   padding: 8px 0;
 }

--- a/src/components/actionMenu/actionMenu.module.scss
+++ b/src/components/actionMenu/actionMenu.module.scss
@@ -19,10 +19,10 @@
 .action-menu {
   display: inline-flex;
   vertical-align: middle;
+}
 
-  .actions-popover {
-    padding: 8px 0;
-  }
+.actions-popover.actions-popover {
+  padding: 8px 0;
 }
 
 .action-dropdown {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored CSS selector structure for the action menu popover component. No changes to visual appearance or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->