### PR TITLE
EPMRPP-113614 || Unnecessary suggestion hint is displayed in "Analyzed Launch" field for non-existing value

### DIFF
--- a/src/components/autocompletes/common/autocompleteOptions.tsx
+++ b/src/components/autocompletes/common/autocompleteOptions.tsx
@@ -50,6 +50,7 @@ export interface AutocompleteOptionsProps<T> {
   newItemButtonText: string;
   limitationText?: string;
   optionsLimit?: number;
+  shouldShowEmptyListMessage?: boolean;
 }
 
 export const AutocompleteOptions = <T,>(props: AutocompleteOptionsProps<T>) => {
@@ -69,6 +70,7 @@ export const AutocompleteOptions = <T,>(props: AutocompleteOptionsProps<T>) => {
     parseValueToString,
     limitationText = 'Too many results. Type to search',
     optionsLimit = 0,
+    shouldShowEmptyListMessage = true,
   } = props;
 
   const filterStaticOptions = useCallback(() => {
@@ -156,13 +158,19 @@ export const AutocompleteOptions = <T,>(props: AutocompleteOptionsProps<T>) => {
 
   const availableOptions = async ? options : filterStaticOptions();
   const prompt = getPrompt(options);
-
   if (prompt) return prompt;
+
+  const areAvailableOptionsEmpty = isEmpty(availableOptions);
+
+  if (areAvailableOptionsEmpty && !shouldShowEmptyListMessage && createWithoutConfirmation)
+    return null;
 
   return (
     <div className={cx({ container: options.length })}>
       <Scrollbars autoHeight autoHeightMax={216} hideTracksWhenNotNeeded>
-        {!isEmpty(availableOptions) ? renderItems(availableOptions) : renderEmptyList()}
+        {areAvailableOptionsEmpty
+          ? shouldShowEmptyListMessage && renderEmptyList()
+          : renderItems(availableOptions)}
         {availableOptions?.length > optionsLimit && optionsLimit > 0 && limitationText ? (
           <li className={cx('limitation-item')} aria-hidden="true">
             {limitationText}

--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -92,6 +92,7 @@ export interface MultipleAutocompleteProps<T> {
   selectedItemTextClassName?: string;
   optionsLimit?: number;
   limitationText?: string;
+  shouldShowEmptyListMessage?: boolean;
 }
 
 export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompleteProps<T>) => {

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -107,6 +107,7 @@ export interface SingleAutocompleteProps<T> {
   newItemButtonText?: string;
   optionsLimit?: number;
   limitationText?: string;
+  shouldShowEmptyListMessage?: boolean;
   /**
    * Portal root element for autocomplete menu rendering.
    * When provided, the menu will be rendered in this element using React Portal.


### PR DESCRIPTION
The AutocompleteOptions and MultipleAutocomplete components had no way to suppress the "No available options" empty list message.

**Changes**

- autocompleteOptions.tsx — Added optional shouldShowEmptyListMessage prop (default true) to AutocompleteOptionsProps. When false and the available options list is empty, the container is not rendered.
- multipleAutocomplete.tsx — Added shouldShowEmptyListMessage to MultipleAutocompleteProps interface so it can be passed through to AutocompleteOptions.

https://github.com/user-attachments/assets/f072ec17-aa57-4d24-b7b7-1d98d428825f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autocomplete controls gain an optional setting to show or hide the empty-state message when no matches are found, available across single, multiple, and shared autocomplete variants.
  * When no options exist and inline creation is enabled, the control can now render nothing instead of displaying an empty-list message, improving layout flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->