### PR TITLE
EPMRPP-114400 || "Manage Assignments" modal window is closed when selecting organization

### DIFF
--- a/src/components/autocompletes/common/autocompleteMenu/autocompleteMenu.tsx
+++ b/src/components/autocompletes/common/autocompleteMenu/autocompleteMenu.tsx
@@ -35,6 +35,7 @@ type AutocompleteMenuProps<T> = {
   className?: string;
   optionsLimit?: number;
   limitationText?: string;
+  portalMenuAttribute?: string | null;
 } & AutocompleteOptionsProps<T>;
 
 export const AutocompleteMenu = forwardRef(
@@ -46,6 +47,7 @@ export const AutocompleteMenu = forwardRef(
       isDropdownMode,
       inputValue = '',
       className = '',
+      portalMenuAttribute = null,
       ...props
     }: AutocompleteMenuProps<T>,
     ref: ForwardedRef<HTMLUListElement>,
@@ -59,6 +61,7 @@ export const AutocompleteMenu = forwardRef(
           className,
         )}
         style={style}
+        {...(portalMenuAttribute ? { [portalMenuAttribute]: '' } : {})}
       >
         <AutocompleteOptions inputValue={inputValue} {...props} />
       </ul>

--- a/src/components/autocompletes/constants.ts
+++ b/src/components/autocompletes/constants.ts
@@ -1,2 +1,3 @@
 export const ENTER_KEY_NAME = 'Enter';
 export const TAB_KEY_NAME = 'Tab';
+export const AUTOCOMPLETE_PORTAL_MENU_ATTR = 'data-autocomplete-portal-menu';

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -35,7 +35,7 @@ import { default as FieldText } from '@/components/fieldText';
 import { DropdownIcon } from '@/components/icons';
 
 import { AutocompleteMenu } from '../common/autocompleteMenu';
-import { ENTER_KEY_NAME, TAB_KEY_NAME } from '../constants';
+import { AUTOCOMPLETE_PORTAL_MENU_ATTR, ENTER_KEY_NAME, TAB_KEY_NAME } from '../constants';
 import { usePreventInitialScroll } from '../hooks/usePreventInitialScroll';
 import { useResizeClose } from '../hooks/useResizeClose';
 import { useScrollClose } from '../hooks/useScrollClose';
@@ -273,6 +273,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
             isDropdownMode={isDropdownMode}
             style={floatingStyles}
             ref={refs.setFloating}
+            portalMenuAttribute={Boolean(menuPortalRoot) ? AUTOCOMPLETE_PORTAL_MENU_ATTR : null}
             minLength={minLength}
             inputValue={(inputValue || '').trim()}
             getItemProps={getOptionProps(getItemProps, highlightedIndex, value)}

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -3,6 +3,7 @@ import { Scrollbars } from 'rc-scrollbars';
 import { motion, AnimatePresence } from 'framer-motion';
 import classNames from 'classnames/bind';
 import { useOnClickOutside, useWindowResize } from '@common/hooks';
+import { AUTOCOMPLETE_PORTAL_MENU_ATTR } from '@components/autocompletes/constants';
 import { DROPDOWN_PORTAL_MENU_ATTR } from '@components/dropdown';
 import { KeyCodes } from '@common/constants/keyCodes';
 import { ButtonProps } from '@components/button';
@@ -132,7 +133,7 @@ export const Modal: FC<ModalProps> = ({
 
   const clickOutsideOptions = useMemo(
     () => ({
-      ignoreSelectors: [`[${DROPDOWN_PORTAL_MENU_ATTR}]`],
+      ignoreSelectors: [`[${DROPDOWN_PORTAL_MENU_ATTR}]`, `[${AUTOCOMPLETE_PORTAL_MENU_ATTR}]`],
     }),
     [],
   );


### PR DESCRIPTION
Add a dedicated portal marker for autocomplete menus and make Modal
outside-click handling ignore those portal nodes.

This prevents modals from closing when a user selects an option from
an autocomplete rendered through a portal.

**Changes**:
- add AUTOCOMPLETE_PORTAL_MENU_ATTR constant
- pass portal marker from SingleAutocomplete to AutocompleteMenu
- render the marker on the autocomplete menu root when portaled
- include autocomplete portal menus in Modal ignoreSelectors

https://github.com/user-attachments/assets/9a8dc515-33bc-4f13-b538-e2d548b24d66