### PR TITLE
Revert #293 due to regression in email dropdown positioning

### DIFF
--- a/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
+++ b/src/components/autocompletes/multipleAutocomplete/multipleAutocomplete.tsx
@@ -249,14 +249,20 @@ export const MultipleAutocomplete = <T,>(componentsProps: MultipleAutocompletePr
           getRootProps,
         }: GetStateAndHelpersT<T>) => {
           const rootProps = getRootProps(undefined, { suppressRefError: true });
+          const modifiedRootProps = {
+            ...rootProps,
+            ref: (node: HTMLDivElement | null) => {
+              refs.setReference(node);
+              return rootProps.ref(node);
+            },
+          };
 
           const downshiftValue = inputValue ?? '';
 
           return (
-            <div {...rootProps} className={cx('autocomplete-wrapper')}>
+            <div {...modifiedRootProps} className={cx('autocomplete-wrapper')}>
               <>
                 <div
-                  ref={refs.setReference}
                   className={cx('autocomplete', customClass, {
                     'mobile-disabled': mobileDisabled,
                     error,

--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -18,7 +18,6 @@ import {
   ComponentProps,
   FocusEvent,
   KeyboardEvent,
-  MutableRefObject,
   ReactNode,
   Ref,
   useState,
@@ -176,24 +175,6 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
     middleware,
   });
 
-  const setInputReference = useCallback(
-    (node: HTMLInputElement | null) => {
-      refs.setReference(node);
-
-      if (!refFunction) {
-        return;
-      }
-
-      if (typeof refFunction === 'function') {
-        refFunction(node);
-        return;
-      }
-
-      (refFunction as MutableRefObject<HTMLInputElement | null>).current = node;
-    },
-    [refs, refFunction],
-  );
-
   usePreventInitialScroll({ skip: shouldSkipPortalActions });
   useResizeClose({ skip: shouldSkipPortalActions, reference: refs.reference });
   useScrollClose({
@@ -264,6 +245,10 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
         const rootProps = getRootProps(undefined, { suppressRefError: true });
         const modifiedRootProps = {
           ...rootProps,
+          ref: (node: HTMLDivElement | null) => {
+            refs.setReference(node);
+            return rootProps.ref(node);
+          },
         };
 
         if (!closeMenuRef.current) {
@@ -316,7 +301,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
                     }
                     onFocus();
                   },
-                  ref: setInputReference,
+                  ref: refFunction,
                   onKeyDown: (event) => {
                     if (event.key === ENTER_KEY_NAME) {
                       event.preventDefault();


### PR DESCRIPTION
## Summary
- Reverts commit from PR #293 (`12e0497`) to roll back a UI regression.
- Restores previous behavior of autocomplete dropdown positioning in email-related inputs.
- Keeps `develop` stable while the original fix can be redesigned safely.

## Test plan
- [x] Verify email dropdown positioning in affected autocomplete fields.
- [x] Confirm no visual regressions in single and multiple autocomplete components.
- [x] Run the existing UI checks used for `ui-kit` PR validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal reference handling in autocomplete components for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->