### PR TITLE
Allow configuring placement for single autocomplete

### DIFF
--- a/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
+++ b/src/components/autocompletes/singleAutocomplete/singleAutocomplete.tsx
@@ -29,7 +29,7 @@ import { createPortal } from 'react-dom';
 import classNames from 'classnames/bind';
 import { isEmpty } from 'es-toolkit/compat';
 import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
-import { autoUpdate, useFloating, size, flip } from '@floating-ui/react';
+import { autoUpdate, useFloating, size, flip, Placement } from '@floating-ui/react';
 
 import { default as FieldText } from '@/components/fieldText';
 import { DropdownIcon } from '@/components/icons';
@@ -101,6 +101,7 @@ export interface SingleAutocompleteProps<T> {
   useFixedPositioning: boolean;
   dropdownMatchInputWidth?: boolean;
   withMenuFlip?: boolean;
+  placement?: Placement;
   getUniqKey?: (item: T) => string;
   customEmptyListMessage?: string;
   customNoMatchesMessage?: string;
@@ -147,6 +148,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
     useFixedPositioning,
     dropdownMatchInputWidth = false,
     withMenuFlip = false,
+    placement: menuPlacement = 'bottom-start',
     newItemButtonText = '',
     menuPortalRoot,
     ...props
@@ -169,7 +171,7 @@ export const SingleAutocomplete = <T,>(componentProps: SingleAutocompleteProps<T
   );
 
   const { refs, floatingStyles } = useFloating({
-    placement: 'bottom-start',
+    placement: menuPlacement,
     whileElementsMounted: autoUpdate,
     strategy,
     middleware,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autocomplete dropdown placement is now customizable. You can configure where the menu appears relative to the input field for improved layout flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/ui-kit/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->